### PR TITLE
Fix new tab for API Reference

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -11,7 +11,7 @@ module.exports = function ($) {
 	$('a').has('button, span').css('border-bottom','0px')
 	$('.markdown-section').has('.api-method-code').css('padding-top','0px');
 	$('.page-inner').has('iframe').contents().find('div, section').css({'height':'100vh','padding':'0px'});
-	$('ul.summary a:contains(Full API Reference),ul.summary a:contains(BXML Reference),ul.summary a:contains(Messaging v2 Reference),ul.summary a:contains(Phone Numbers Reference) ').removeAttr('target');
+	$('ul.summary a:contains(Voice & Messaging API Reference),ul.summary a:contains(BXML Reference),ul.summary a:contains(Messaging v2 Reference),ul.summary a:contains(Phone Numbers Reference) ').removeAttr('target');
 	$('.footerListItem a, a[href*="docs/phone-numbers"]').removeAttr('target');
   var helperPages = [
     'callScreen.html'


### PR DESCRIPTION
Update the custom.js file to force the API reference to open in the same tab

## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `gitbook` 

- [x] I made sure that the site looks great and functions perfectly live
- [x] I ran splell check
- [x] I'm ready for these changes to be made live

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [ ] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [x] I did these things
- [x] I'm ready for these changes to be made live

