### PR TITLE
TDP-2681 change the bxml Pause verb default value

### DIFF
--- a/voice/bxml/verbs/pause.md
+++ b/voice/bxml/verbs/pause.md
@@ -7,7 +7,7 @@ The Pause verb is used to delay for a set period of time.  Silence will be heard
 
 | ATTRIBUTE | Description                                                                                            |
 |:----------|:-------------------------------------------------------------------------------------------------------|
-| duration  | The 'duration' attribute specifies how many seconds Bandwidth will wait silently before continuing on. |
+| duration  | (optional) The 'duration' attribute specifies how many seconds Bandwidth will wait silently before continuing on. Default value is 1. |
 
 
 ### Callbacks Received


### PR DESCRIPTION
## For the Committer

Small update on the bxml pause verb: added default value.

## For the Reviewer

### General Review

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.
