### PR TITLE
DX598: update helper pages and external urls

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -47,10 +47,10 @@ module.exports = function ($) {
 	});
 
 	// Add external link icon to all links in summary
-   $('ul.summary a[target=_blank]').each(function () {
-        var href = $(this); // retrive href foreach a
-        $(this).append('&nbsp;<i class="icons8-open-in-window"></i>');
-    });
+	$('ul.summary a[target=_blank]').each(function () {
+		var href = $(this); // retrive href foreach a
+		$(this).append('&nbsp;<i class="icons8-open-in-window"></i>');
+	});
 
 	// Remove gitbook branding
 	$('.gitbook-link').remove()

--- a/js/custom.js
+++ b/js/custom.js
@@ -24,14 +24,17 @@ module.exports = function ($) {
 	});
 
 	var helperPages = [
-		'uisetup.html',
-		'apisetup.html',
+		'onDemandNumberSearchAndOrder.html',
 		'numberOrderingSummary.html',
-		'codes.html',
-		'billingAndMpsGuidelines.html'
+		'advancedOrdering.html',
+		'disconnectSummary.html',
+		'managingLineFeatures.html',
+		'managingOrders.html',
+		'reporting.html',
+		'portingPhoneNumbers.html',
+		'ratelimits.html',
+		'codes.html'
 	];
-
-
 
 	$('li.chapter a').each(function(i, elem) {
 		var a = $(elem);
@@ -42,8 +45,16 @@ module.exports = function ($) {
 			}
 		});
 	});
-	var title = $('title').text();
 
+	// Add external link icon to all links in summary
+   $('ul.summary a[target=_blank]').each(function () {
+        var href = $(this); // retrive href foreach a
+        $(this).append('&nbsp;<i class="icons8-open-in-window"></i>');
+    });
+
+	// Remove gitbook branding
+	$('.gitbook-link').remove()
+	var title = $('title').text();
 
 	if(title.indexOf(' · GitBook')  > 0) {
 		var newTitle = title.replace(' · GitBook', '');


### PR DESCRIPTION
* In the custom.js page for stop gap there is a list of "helperPages" that need the `#top` appended to them for best functionality.
* Gitbook branding removed
* The pages that open in new tabs now include the external page icon.

### Code Changes

```js
var helperPages = [
	'onDemandNumberSearchAndOrder.html',
	'numberOrderingSummary.html',
	'advancedOrdering.html',
	'disconnectSummary.html',
	'managingLineFeatures.html',
	'managingOrders.html',
	'reporting.html',
	'portingPhoneNumbers.html',
	'ratelimits.html',
	'codes.html'
];
```

```js
// Add external link icon to all links in summary
$('ul.summary a[target=_blank]').each(function () {
	var href = $(this); // retrive href foreach a
	$(this).append('&nbsp;<i class="icons8-open-in-window"></i>');
});
```
