### PR TITLE
TDP-3069: Specify TransferAnswer BXML Verbs

### DIFF
--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -1,8 +1,8 @@
 {% method %}
 ##  Transfer Answer Event – <Transfer> verb
 When processing a `<Transfer>` verb, this event is sent when a called party (B-leg) answers.  The event is sent to
-  the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  BXML returned by this callback will be
-  executed for the called party only.  At the conclusion of the BXML, the called party will be bridged to the original
+  the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  `<PlayAudio>` and/or `<SpeakSentence>` verbs returned by this callback will be
+  executed for the called party only.  No other BXML verbs may be specified.  At the conclusion of the BXML, the called party will be bridged to the original
   call.
 
 ### Expected response
@@ -11,7 +11,7 @@ HTTP/1.1 200
 Content-Type: application/xml; charset=utf-8
 
 <Response>
-    <!-- BXML verbs to announce to called party -->
+    <!-- <PlayAudio> or <SpeakSentence> BXML verbs to announce to called party -->
 </Response>
 ```
 

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -2,7 +2,7 @@
 ##  Transfer Answer Event – <Transfer> verb
 When processing a [`<Transfer>`](../verbs/transfer.md) verb, this event is sent when a called party (B-leg) answers.  The event is sent to
   the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  [`<PlayAudio>`](../verbs/playAudio.md) and/or [`<SpeakSentence>`](../verbs/speakSentence.md) verbs returned by this callback will be
-  executed for the called party only.  No other BXML verbs may be specified.  At the conclusion of the BXML, the called party will be bridged to the original
+  executed for the called party only.  No other BXML verbs may be specified.  Afterward, the called party will be bridged to the original
   call.
 
 ### Expected response

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -1,7 +1,7 @@
 {% method %}
 ##  Transfer Answer Event – <Transfer> verb
-When processing a `<Transfer>` verb, this event is sent when a called party (B-leg) answers.  The event is sent to
-  the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  `<PlayAudio>` and/or `<SpeakSentence>` verbs returned by this callback will be
+When processing a [`<Transfer>`](../verbs/transfer.md) verb, this event is sent when a called party (B-leg) answers.  The event is sent to
+  the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  [`<PlayAudio>`](../verbs/playAudio.md) and/or [`<SpeakSentence>`](../verbs/speakSentence.md) verbs returned by this callback will be
   executed for the called party only.  No other BXML verbs may be specified.  At the conclusion of the BXML, the called party will be bridged to the original
   call.
 

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -11,7 +11,7 @@ HTTP/1.1 200
 Content-Type: application/xml; charset=utf-8
 
 <Response>
-    <!-- <PlayAudio> or <SpeakSentence> BXML verbs to announce to called party -->
+    <!-- <PlayAudio> or <SpeakSentence> BXML verbs to announce to the called party -->
 </Response>
 ```
 

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -11,7 +11,7 @@ HTTP/1.1 200
 Content-Type: application/xml; charset=utf-8
 
 <Response>
-    <!-- <PlayAudio> or <SpeakSentence> BXML verbs to announce to the called party -->
+    <!-- <PlayAudio> or <SpeakSentence> BXML verbs to play to the called party -->
 </Response>
 ```
 


### PR DESCRIPTION
## For the Committer

~⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `gitbook`~

- [x] I made sure that the site looks great and functions perfectly live
- [x] I ran splell check
- [ ] I'm ready for these changes to be made live

## For the Reviewer

### General Review

Look [here](http://bw-dev-tdp-3069-specify-transfer-answer-verbs.s3-website-us-east-1.amazonaws.com/voice/bxml/callbacks/transferAnswer.html) to see the new version of the `TransferAnswer` documentation.

- [ ] All changes/updates requested were intentionally changed or added (no extraneous file or partial updates)
- [ ] The live rendered page behaves and looks like intended.
- [ ] All links work as intended. (click every link to make sure that it takes the user to the expected place).
- [ ] The markdown was rendered to HTML as intended. (Tables look right, code samples are gated properly).
- [ ] Any style or CSS changes are tested on multiple different pages to ensure nothing unexpected broke or changed.
- [ ] I proof-read the live site (`gitbook serve`) and there are no oblivious splelling or grammer misteaks.

### Gitbook Specific

- [ ] Any new documentation pages have been added to the `SUMMARY.md` file so they are rendered to HTML.
- [x] Any links to other pages within this documentation use relative links (`[read more about ...](guides/voice/voicemail.md)`).
- [ ] Gitbook can install and build the documentation (`gitbook install` & `gitbook build`)

### Code Specific

- [ ] All code has been tested against the live API.
- [ ] All code can be run without throwing errors or **new** warnings.
- [ ] All code is formatted correctly and consistently (spaces, tabs).
- [ ] All code is legible and idiomatic to the language.
- [ ] All code uses sensical method, function, and variable names.
- [ ] All code samples use the appropriate syntax highlighting.
- [ ] Any examples re-use same phone numbers, uuids, variable names, etc... throughout (IE don't have something like `{from: '+19191231234', to: '+19191231234'}` unless it's meant to show the same phone number calling/texting itself ).

## TL;DR

- [ ] I did these things
- [ ] I'm ready for these changes to be made live

