### PR TITLE
Update transferAnswer.md

### DIFF
--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -2,8 +2,10 @@
 ##  Transfer Answer Event – <Transfer> verb
 When processing a [`<Transfer>`](../verbs/transfer.md) verb, this event is sent when a called party (B-leg) answers.  The event is sent to
   the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  [`<PlayAudio>`](../verbs/playAudio.md) and/or [`<SpeakSentence>`](../verbs/speakSentence.md) verbs returned by this callback will be
-  executed for the called party only.  No other BXML verbs may be specified.  Afterward, the called party will be bridged to the original
+  executed for the called party only. Afterward, the called party will be bridged to the original
   call.
+  
+  It is important to note that no other BXML verbs may be specified after a Transfer Answer Event is called.
 
 ### Expected response
 ```http


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes
Updated the transferAnswer.md file to clearly specify that users are unable to specify any more bxml verbs after transferAnswer
