### PR TITLE
AJ docs update

### DIFF
--- a/messaging/about.md
+++ b/messaging/about.md
@@ -56,6 +56,8 @@ This indicates the number of segments the original message from the user is brok
 
 The value `segmentCount` is returned in the callback events and the response when creating the message.
 
+For mored detailed information on segment counts, please see our [character limits and concatenation practices](https://support.bandwidth.com/hc/en-us/articles/360010235373-What-Are-Bandwidth-s-SMS-Character-Limits-Concatenation-Practices-).
+
 ## MMS and Group Message Delivery Receipts {#mms-dlr}
 
 MMS and Group messages **don’t** currently support delivery receipts. However, you will still receive a message delivered event when the message is sent. For _only MMS and Group Messages_ this means that your message has been handed off to the Bandwidth core network, but has not been confirmed at the downstream carrier. We are actively working to support true delivery receipts for the v2 Messaging API.

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -2,8 +2,10 @@
 ##  Transfer Answer Event – <Transfer> verb
 When processing a [`<Transfer>`](../verbs/transfer.md) verb, this event is sent when a called party (B-leg) answers.  The event is sent to
   the endpoint specified in the `transferAnswerUrl` attribute of the `<PhoneNumber>` tag that answered.  [`<PlayAudio>`](../verbs/playAudio.md) and/or [`<SpeakSentence>`](../verbs/speakSentence.md) verbs returned by this callback will be
-  executed for the called party only.  No other BXML verbs may be specified.  Afterward, the called party will be bridged to the original
+  executed for the called party only. Afterward, the called party will be bridged to the original
   call.
+  
+  It is important to note that no other BXML verbs may be specified after a Transfer Answer Event is called.
 
 ### Expected response
 ```http


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes
Updated the messaging overview page - specifically messaging segments - to include a link to a more detailed blog post in an attempt to clear up customer confusion regarding segment counts and character limits. 

