### PR TITLE
TDP-4690: answerTime in call callback events.

### DIFF
--- a/voice/bxml/callbacks/answer.md
+++ b/voice/bxml/callbacks/answer.md
@@ -15,18 +15,19 @@ Content-Type: application/xml; charset=utf-8
 ```
 
 ### Properties
-| Property  | Description                                                                                                     |
-|:----------|:----------------------------------------------------------------------------------------------------------------|
-| eventType | The event type, value is `answer`                                                                               |
+| Property      | Description                                                                                                     |
+|:--------------|:----------------------------------------------------------------------------------------------------------------|
+| eventType     | The event type, value is `answer`                                                                               |
 | accountId     | The user account associated with the call.                                                                      |
 | applicationId | The id of the application associated with the call.                                                             |
-| to        | The phone number that received the call, in E.164 format (e.g. +15555555555).                                   |
-| from      | The phone number that made the call, in E.164 format (e.g. +15555555555).                                       |
-| direction | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes.               |
-| callId    | The call id associated with the event.                                                                          |
-| callUrl   | The URL of the call associated with the event.                                                                  |
-| startTime | Time the call was started, in ISO 8601 format.                                                                  |
-| tag       | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null. |
+| to            | The phone number that received the call, in E.164 format (e.g. +15555555555).                                   |
+| from          | The phone number that made the call, in E.164 format (e.g. +15555555555).                                       |
+| direction     | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes.               |
+| callId        | The call id associated with the event.                                                                          |
+| callUrl       | The URL of the call associated with the event.                                                                  |
+| startTime     | Time the call was started, in ISO 8601 format.                                                                  |
+| answerTime    | Time the call was answered, in ISO 8601 format.                                                                 |
+| tag           | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null. |
 
 {% common %}
 #### Example: Basic answer event

--- a/voice/bxml/callbacks/answer.md
+++ b/voice/bxml/callbacks/answer.md
@@ -46,7 +46,8 @@ POST http://[External server URL]
 	"direction"     : "outbound",
 	"callId"        : "c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"callUrl"       : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
-	"startTime"     : "2019-06-20T15:54:22.234Z"
+	"startTime"     : "2019-06-20T15:54:22.234Z",
+	"answerTime"    : "2019-06-20T15:54:25.432Z"
 }
 ```
 
@@ -66,6 +67,7 @@ POST http://[External server URL]
 	"callId"        : "c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"callUrl"       : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"     : "2019-06-20T15:54:22.234Z",
+	"answerTime"    : "2019-06-20T15:54:25.432Z",
 	"tag"           : "example-tag"
 }
 ```

--- a/voice/bxml/callbacks/bridgeComplete.md
+++ b/voice/bxml/callbacks/bridgeComplete.md
@@ -53,6 +53,7 @@ POST http://[External server URL]
 	"callId"           : "c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"callUrl"          : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
+	"answerTime"       : "2019-07-31T13:13:40.644Z",
 	"cause"            : "",
 	"errorMessage"     : "",
 	"errorId"          : ""
@@ -78,6 +79,7 @@ POST http://[External server URL]
 	"transferCallerId" : "+15551115555",
 	"transferTo"       : "+15556667777",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
+	"answerTime"       : "2019-07-31T13:13:40.644Z",
 	"cause"            : "busy",
 	"errorMessage"     : "Call c-2a913f94-6a486f3a-3cae-4034-bcc3-f0c9fa77ca2f is already bridged with another call",
 	"errorId"          : "4642074b-7b58-478b-96e4-3a60955c6765"

--- a/voice/bxml/callbacks/bridgeComplete.md
+++ b/voice/bxml/callbacks/bridgeComplete.md
@@ -28,8 +28,9 @@ Content-Type: application/xml; charset=utf-8
 | callId           | The call id associated with the event.                                                                    |
 | callUrl          | The URL of the call associated with the event.                                                            |
 | startTime        | Time the call was started, in ISO 8601 format.                                                            |
+| answerTime 	   | Time the call was answered, in ISO 8601 format.                                                           |
 | tag              | The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.    |
-| cause            | Reason the bridge failed - `busy`, `rejected`, or `unknown`.                               |
+| cause            | Reason the bridge failed - `busy`, `rejected`, or `unknown`.                               			   |
 | errorMessage     | Text explaining the reason that caused the bridge to fail in case of errors.                              |
 | errorId          | Bandwidth internal id that references the error event.                                                    |
 

--- a/voice/bxml/callbacks/bridgeTargetComplete.md
+++ b/voice/bxml/callbacks/bridgeTargetComplete.md
@@ -26,6 +26,7 @@ Content-Type: application/xml; charset=utf-8
 | callId           | The bridge target call id.                                                                                |
 | callUrl          | The URL of the call associated with the event.                                                            |
 | startTime        | Time the call was started, in ISO 8601 format.                                                            |
+| answerTime       | Time the call was answered, in ISO 8601 format.                                                           |
 | tag              | The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.    |
 
 {% common %}

--- a/voice/bxml/callbacks/bridgeTargetComplete.md
+++ b/voice/bxml/callbacks/bridgeTargetComplete.md
@@ -48,6 +48,7 @@ POST http://[External server URL]
 	"callId"           : "c-2a913f94-6a486f3a-3cae-4034-bcc3-f0c9fa77ca2f",
 	"callUrl"          : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
+	"answerTime"       : "2019-07-31T13:13:40.644Z"
 }
 ```
 

--- a/voice/bxml/callbacks/gather.md
+++ b/voice/bxml/callbacks/gather.md
@@ -49,6 +49,7 @@ POST http://[External server URL]
 	"accountId"        : "55555555",
 	"applicationId"    : "7fc9698a-b04a-468b-9e8f-91238c0d0086",
 	"startTime"        : "2019-06-20T15:54:22.234Z",
+	"answerTime"   	   : "2019-06-20T15:54:25.432Z",
 	"from"             : "+15551112222",
 	"to"               : "+15553334444",
 	"direction"        : "outbound",
@@ -76,6 +77,7 @@ POST http://[External server URL]
 	"callId"           : "c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"callUrl"          : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"        : "2019-06-20T15:54:22.234Z",
+	"answerTime"       : "2019-06-20T15:54:25.432Z",
 	"digits"           : "123",
 	"terminatingDigit" : "#"
 }

--- a/voice/bxml/callbacks/gather.md
+++ b/voice/bxml/callbacks/gather.md
@@ -28,6 +28,7 @@ Content-Type: application/xml; charset=utf-8
 | parentCallId     | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                                           |
 | callUrl          | The URL of the call associated with the event.                                                                                                                                                     |
 | startTime        | Time the call was started, in ISO 8601 format.                                                                                                                                                     |
+| answerTime       | Time the call was answered, in ISO 8601 format.                                                                                                                                                    |
 | tag              | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                                                                  |
 | digits           | (optional) The digits collected from user.  Null if a timeout occurred before any digits were pressed.                                                                                             |
 | terminatingDigit | (optional) The digit the user pressed to end the gather.  Null if no terminating digit was pressed.                                                                                                |

--- a/voice/bxml/callbacks/recordComplete.md
+++ b/voice/bxml/callbacks/recordComplete.md
@@ -29,8 +29,8 @@ Content-Type: application/xml; charset=utf-8
 | parentCallId      | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                                              |
 | recordingId       | The unique id for this recording.                                                                                                                                                                     |
 | callUrl           | The URL of the call associated with the event.                                                                                                                                                        |
-| answerTime        | Time the call was answered, in ISO 8601 format.                                                                                                                                                       |
 | mediaUrl          | URL to retrieve the contents of the recording.                                                                                                                                                        |
+| answerTime        | Time the call was answered, in ISO 8601 format.                                                                                                                                                       |
 | startTime         | Time the recording was started, in ISO 8601 format.                                                                                                                                                   |
 | endTime           | Time the recording ended, in ISO 8601 format.                                                                                                                                                         |
 | duration          | Duration of the recording, in ISO 8601 format.                                                                                                                                                        |
@@ -60,6 +60,7 @@ POST http://[External server URL]
 	"recordingId"   : "r-115da407-e3d9-4ea7-889f-5f4ad7386a80",
 	"callUrl"       : "https://../{accountId}/calls/{callId-1}",
 	"channels"      : 1,
+	"answerTime"    : "2019-09-13T16:48:26.665Z",
 	"startTime"     : "2019-09-13T16:48:29.235Z",
 	"endTime"       : "2019-09-13T16:48:48.890Z",
 	"duration"      : "PT20.056S",

--- a/voice/bxml/callbacks/recordComplete.md
+++ b/voice/bxml/callbacks/recordComplete.md
@@ -29,6 +29,7 @@ Content-Type: application/xml; charset=utf-8
 | parentCallId      | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                                              |
 | recordingId       | The unique id for this recording.                                                                                                                                                                     |
 | callUrl           | The URL of the call associated with the event.                                                                                                                                                        |
+| answerTime        | Time the call was answered, in ISO 8601 format.                                                                                                                                                       |
 | mediaUrl          | URL to retrieve the contents of the recording.                                                                                                                                                        |
 | startTime         | Time the recording was started, in ISO 8601 format.                                                                                                                                                   |
 | endTime           | Time the recording ended, in ISO 8601 format.                                                                                                                                                         |
@@ -36,8 +37,8 @@ Content-Type: application/xml; charset=utf-8
 | channels          | Number of channels in the recording.                                                                                                                                                                  |
 | fileFormat        | The audio format that the recording was saved as (`wav` or `mp3`).                                                                                                                                    |
 | tag               | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                                                                     |
-| transferCallerId | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555). Otherwise, null.                  |
-| transferTo       | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `to` field of the B-leg call in E.164 format (e.g. +15555555555). Otherwise, null.                     |
+| transferCallerId  | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555). Otherwise, null.                 |
+| transferTo        | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `to` field of the B-leg call in E.164 format (e.g. +15555555555). Otherwise, null.                    |
 
 {% common %}
 

--- a/voice/bxml/callbacks/redirect.md
+++ b/voice/bxml/callbacks/redirect.md
@@ -27,7 +27,7 @@ Content-Type: application/xml; charset=utf-8
 | parentCallId     | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                              |
 | callUrl          | The URL of the call associated with the event.                                                                                                                                        |
 | startTime        | Time the call was started, in ISO 8601 format.                                                                                                                                        |
-| answerTime       | Time the call was answered, in ISO 8601 format.                                                                  																	   |
+| answerTime       | (optional) Time the call was answered, in ISO 8601 format.                                                                                                                            |
 | tag              | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                                                     |
 | transferCallerId | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555). Otherwise, null. |
 | transferTo       | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `to` field of the B-leg call in E.164 format (e.g. +15555555555). Otherwise, null.    |

--- a/voice/bxml/callbacks/redirect.md
+++ b/voice/bxml/callbacks/redirect.md
@@ -70,6 +70,7 @@ POST http://[External server URL]
 	"callId"        : "c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"callUrl"       : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"     : "2019-06-20T15:54:22.234Z",
+	"answerTime"    : "2019-06-20T15:54:25.432Z",
 	"tag"           : "example-tag"
 }
 ```

--- a/voice/bxml/callbacks/redirect.md
+++ b/voice/bxml/callbacks/redirect.md
@@ -15,21 +15,22 @@ Content-Type: application/xml; charset=utf-8
 ```
 
 ### Properties
-| Property          | Description                                                                                                                                                                           |
-|:------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| eventType         | The event type, value is `redirect`.                                                                                                                                                  |
-| accountId         | The user account associated with the call.                                                                                                                                            |
-| applicationId     | The id of the application associated with the call.                                                                                                                                   |
-| to                | The phone number that received the call, in E.164 format (e.g. +15555555555).                                                                                                         |
-| from              | The phone number that made the call, in E.164 format (e.g. +15555555555).                                                                                                             |
-| direction         | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes.                                                                                     | 
-| callId            | The call id associated with the event.                                                                                                                                                |
-| parentCallId     | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                               |
-| callUrl           | The URL of the call associated with the event.                                                                                                                                        |
-| startTime         | Time the call was started, in ISO 8601 format.                                                                                                                                        |
-| tag               | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                                                     |
-| transferCallerId | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555). Otherwise, null.  |
-| transferTo       | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `to` field of the B-leg call in E.164 format (e.g. +15555555555). Otherwise, null.     |
+| Property         | Description                                                                                                                                                                           |
+|:-----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| eventType        | The event type, value is `redirect`.                                                                                                                                                  |
+| accountId        | The user account associated with the call.                                                                                                                                            |
+| applicationId    | The id of the application associated with the call.                                                                                                                                   |
+| to               | The phone number that received the call, in E.164 format (e.g. +15555555555).                                                                                                         |
+| from             | The phone number that made the call, in E.164 format (e.g. +15555555555).                                                                                                             |
+| direction        | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes.                                                                                     | 
+| callId           | The call id associated with the event.                                                                                                                                                |
+| parentCallId     | (optional) If the event is related to the B leg of a `<Transfer>`, the call id of the original call leg that executed the `<Transfer>`. Otherwise, null.                              |
+| callUrl          | The URL of the call associated with the event.                                                                                                                                        |
+| startTime        | Time the call was started, in ISO 8601 format.                                                                                                                                        |
+| answerTime       | Time the call was answered, in ISO 8601 format.                                                                  																	   |
+| tag              | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                                                     |
+| transferCallerId | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555). Otherwise, null. |
+| transferTo       | (optional) If the event is related to the B leg of a `<Transfer>`, the phone number used as the `to` field of the B-leg call in E.164 format (e.g. +15555555555). Otherwise, null.    |
 
 {% common %}
 

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -72,6 +72,7 @@ POST http://[External server URL]
 	"parentCallId"     : "c-2a913f94-6a486f3a-3cae-4034-bcc3-f0c9fa77ca2f",
 	"callUrl"          : "https://voice.bandwidth.com/api/v2/accounts/55555555/calls/c-95ac8d6e-1a31c52e-b38f-4198-93c1-51633ec68f8d",
 	"startTime"        : "2019-06-20T15:54:22.234Z",
+	"answerTime"       : "2019-06-20T15:54:25.432Z",
 	"transferTo"       : "+15556667777",
 	"transferCallerId" : "+15551112222"
 }

--- a/voice/bxml/callbacks/transferAnswer.md
+++ b/voice/bxml/callbacks/transferAnswer.md
@@ -44,9 +44,10 @@ Content-Type: application/xml; charset=utf-8
 | to               | The phone number used in the `to` field of the original call, in E.164 format (e.g. +15555555555).                |
 | direction        | The direction of the call. Always `outbound` for this event.                                                      |
 | callId           | The call id of the newly-created B leg.                                                                           |
-| parentCallId     | The call id of the original call leg that executed the `<Transfer>` tag.                                         |
+| parentCallId     | The call id of the original call leg that executed the `<Transfer>` tag.                                          |
 | callUrl          | The URL of the call associated with the event.                                                                    |
 | startTime        | Time the call was started, in ISO 8601 format.                                                                    |
+| answerTime       | Time the call was answered, in ISO 8601 format.                                                                   |
 | tag              | (optional) The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null. |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                 |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                   |

--- a/voice/bxml/callbacks/transferComplete.md
+++ b/voice/bxml/callbacks/transferComplete.md
@@ -27,6 +27,7 @@ Content-Type: application/xml; charset=utf-8
 | callId           | The call id associated with the event.                                                                                                |
 | callUrl          | The URL of the call associated with the event.                                                                                        |
 | startTime        | Time the call was started, in ISO 8601 format.                                                                                        |
+| answerTime       | Time the call was answered, in ISO 8601 format.                                                                                       |
 | tag              | The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                                     |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                                       |

--- a/voice/bxml/callbacks/transferComplete.md
+++ b/voice/bxml/callbacks/transferComplete.md
@@ -82,7 +82,7 @@ POST http://[External server URL]
 	"transferCallerId" : "+15551115555",
 	"transferTo"       : "+15556667777",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
-	"answerTime"       : "2019-06-20T15:54:25.432Z",
+	"answerTime"       : "2019-07-31T13:13:40.644Z",
 	"cause"            : "busy",
 	"errorMessage"     : "Callee is busy",
 	"errorId"          : "4642074b-7b58-478b-96e4-3a60955c6765"

--- a/voice/bxml/callbacks/transferComplete.md
+++ b/voice/bxml/callbacks/transferComplete.md
@@ -56,6 +56,7 @@ POST http://[External server URL]
 	"transferCallerId" : "+15551115555",
 	"transferTo"       : "+15556667777",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
+	"answerTime"       : "2019-07-31T13:13:40.644Z",
 	"cause"            : "hangup",
 	"errorMessage"     : "",
 	"errorId"          : ""
@@ -81,6 +82,7 @@ POST http://[External server URL]
 	"transferCallerId" : "+15551115555",
 	"transferTo"       : "+15556667777",
 	"startTime"        : "2019-07-31T13:13:34.859Z",
+	"answerTime"       : "2019-06-20T15:54:25.432Z",
 	"cause"            : "busy",
 	"errorMessage"     : "Callee is busy",
 	"errorId"          : "4642074b-7b58-478b-96e4-3a60955c6765"


### PR DESCRIPTION
## Brief Summary of changes

Add `answerTime` to all call callback events except `recordingAvailable` and `transcriptionAvailable`