### PR TITLE
TDP-3842: No secrets in callbackUrls

### DIFF
--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -11,12 +11,16 @@ Creates a new outbound phone call.
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
+{% raw %}
+
 <aside class="alert general">
 <p><b>
 IMPORTANT NOTE ABOUT AUTHORIZATION!
 </p></b>
 You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
 </aside>
+
+{% endraw %}
 
 
 ---

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -12,11 +12,9 @@ Creates a new outbound phone call.
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 
-<aside class="alert general small">
-<p>
-IMPORTANT NOTE ABOUT AUTHORIZATION!
-
-You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.</p>
+<aside class="alert general">
+<p>IMPORTANT NOTE ABOUT AUTHORIZATION!</p>
+You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
 </aside>
 
 

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -11,6 +11,8 @@ Creates a new outbound phone call.
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
+You should not include sensitive or personally-identifiable information in any url field! Always use the proper username and password fields for authorization.
+
 ---
 
 ### Supported Parameters

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -15,7 +15,7 @@ You should not include sensitive or personally-identifiable information in any t
 
 ---
 
-### Supported Parameters
+### Supported Parameters 
 
 | Parameter          | Description                                                                                                                                                                                                             | Mandatory |
 |:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------     |:----------|

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -11,11 +11,17 @@ Creates a new outbound phone call.
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
+<aside class="alert general">
+<p><b>
+IMPORTANT NOTE ABOUT AUTHORIZATION!
+</p></b>
 You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
+</aside>
+
 
 ---
 
-### Supported Parameters 
+### Supported Parameters
 
 | Parameter          | Description                                                                                                                                                                                                             | Mandatory |
 |:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------     |:----------|

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -11,7 +11,7 @@ Creates a new outbound phone call.
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
-You should not include sensitive or personally-identifiable information in any url field! Always use the proper username and password fields for authorization.
+You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
 
 ---
 

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -11,16 +11,13 @@ Creates a new outbound phone call.
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
-{% raw %}
 
-<aside class="alert general">
-<p><b>
+<aside class="alert general small">
+<p>
 IMPORTANT NOTE ABOUT AUTHORIZATION!
-</p></b>
-You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
-</aside>
 
-{% endraw %}
+You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.</p>
+</aside>
 
 
 ---

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -14,7 +14,7 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 
 <aside class="alert general">
 <p>IMPORTANT NOTE ABOUT AUTHORIZATION!</p>
-You should not include sensitive or personally-identifiable information in any tag or url field! Always use the proper username and password fields for authorization.
+You should not include sensitive or personally-identifiable information in any tag or URL field! Always use the proper username and password fields for authorization.
 </aside>
 
 

--- a/voice/methods/recordings/postCallsCallIdRecordingsRecordingIdTranscription.md
+++ b/voice/methods/recordings/postCallsCallIdRecordingsRecordingIdTranscription.md
@@ -12,13 +12,14 @@ Generate the transcription for a specific recording. Transcription can succeed o
 
 Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Credentials. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
+
 ---
 
 ### Supported Parameters
 
 | Parameter      | Description                                                                                            | Mandatory |
 |:---------------|:-------------------------------------------------------------------------------------------------------|:----------|
-| callbackUrl    | The URL to send the [TranscriptionAvailable](../../bxml/callbacks/transcriptionAvailable.md) event to. | No        |
+| callbackUrl    | The URL to send the [TranscriptionAvailable](../../bxml/callbacks/transcriptionAvailable.md) event to. You should not include sensitive or personally-identifiable information in the callbackUrl field! Always use the proper username and password fields for authorization. | No        |
 | callbackMethod | The HTTP method to use for the request to `callbackUrl`. GET or POST. Default value is POST.           | No        |
 | username       | The username to send in the HTTP request to `callbackUrl`.                                             | No        |
 | password       | The password to send in the HTTP request to `callbackUrl`.                                             | No        |


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes
Added a reminder to use proper auth fields, not to dump secrets into the callbackUrl
