### PR TITLE
Clarify recording complete callback is only sent still active calls

### DIFF
--- a/voice/bxml/callbacks/recordComplete.md
+++ b/voice/bxml/callbacks/recordComplete.md
@@ -1,7 +1,7 @@
 {% method %}
 ##  Record Complete event
 
-The Record Complete event is sent after a [`<Record>`](../verbs/record.md) verb has executed and the BXML returned by this callback is executed next.
+The Record Complete event is sent after a [`<Record>`](../verbs/record.md) verb has executed if the call is still active. The BXML returned by this callback is executed next.
 
 When the recording is available for download, a [Recording Available](recordingAvailable.md) event will be sent.
 

--- a/voice/bxml/verbs/record.md
+++ b/voice/bxml/verbs/record.md
@@ -7,7 +7,7 @@ Bandwidth will keep recordings for up to 30 days. After 30 days the recordings w
 ### Attributes
 | Attribute                    | Description |
 |:-----------------------------|:------------|
-| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once it has ended. Accepts BXML, and may be a relative URL. |
+| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once the recording has ended. Accepts BXML, and may be a relative URL. This callback will not be sent if the recording ended because of a `hangup` event. |
 | recordCompleteMethod         | (optional) The HTTP method to use for the request to `recordCompleteUrl`. GET or POST. Default value is POST. |
 | recordCompleteFallbackUrl    | (optional) A fallback url which, if provided, will be used to retry the [Record Complete](../callbacks/recordComplete.md) callback delivery in case `recordCompleteUrl` fails to respond. |
 | recordCompleteFallbackMethod | (optional) The HTTP method to use to deliver the [Record Complete](../callbacks/recordComplete.md) callback to `recordCompleteFallbackUrl`. GET or POST. Default value is POST. |

--- a/voice/bxml/verbs/record.md
+++ b/voice/bxml/verbs/record.md
@@ -7,7 +7,7 @@ Bandwidth will keep recordings for up to 30 days. After 30 days the recordings w
 ### Attributes
 | Attribute                    | Description |
 |:-----------------------------|:------------|
-| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once the recording has ended. Accepts BXML, and may be a relative URL. This callback will not be sent if the recording ended because of a `hangup` event and hence is no longer active. |
+| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once the recording has ended. Accepts BXML, and may be a relative URL. This callback will not be sent if the recording ended due to the call hanging up. |
 | recordCompleteMethod         | (optional) The HTTP method to use for the request to `recordCompleteUrl`. GET or POST. Default value is POST. |
 | recordCompleteFallbackUrl    | (optional) A fallback url which, if provided, will be used to retry the [Record Complete](../callbacks/recordComplete.md) callback delivery in case `recordCompleteUrl` fails to respond. |
 | recordCompleteFallbackMethod | (optional) The HTTP method to use to deliver the [Record Complete](../callbacks/recordComplete.md) callback to `recordCompleteFallbackUrl`. GET or POST. Default value is POST. |

--- a/voice/bxml/verbs/record.md
+++ b/voice/bxml/verbs/record.md
@@ -7,7 +7,7 @@ Bandwidth will keep recordings for up to 30 days. After 30 days the recordings w
 ### Attributes
 | Attribute                    | Description |
 |:-----------------------------|:------------|
-| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once the recording has ended. Accepts BXML, and may be a relative URL. This callback will not be sent if the recording ended because of a `hangup` event. |
+| recordCompleteUrl            | (optional) URL to send the [Record Complete](../callbacks/recordComplete.md) event to once the recording has ended. Accepts BXML, and may be a relative URL. This callback will not be sent if the recording ended because of a `hangup` event and hence is no longer active. |
 | recordCompleteMethod         | (optional) The HTTP method to use for the request to `recordCompleteUrl`. GET or POST. Default value is POST. |
 | recordCompleteFallbackUrl    | (optional) A fallback url which, if provided, will be used to retry the [Record Complete](../callbacks/recordComplete.md) callback delivery in case `recordCompleteUrl` fails to respond. |
 | recordCompleteFallbackMethod | (optional) The HTTP method to use to deliver the [Record Complete](../callbacks/recordComplete.md) callback to `recordCompleteFallbackUrl`. GET or POST. Default value is POST. |


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes

Clarified that recordComplete callback will only be sent if the recording did not end because of a hangup event (because there's not point, can't gather BXML for a dead call).