### PR TITLE
TDP-4628 Clarify disconnect causes

### DIFF
--- a/voice/bxml/callbacks/disconnect.md
+++ b/voice/bxml/callbacks/disconnect.md
@@ -2,18 +2,20 @@
 ## Disconnect Event
 
 The Disconnect event is fired when a call ends, for any reason. The `cause` for a disconnect event on a call can be:
-- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `hangup`: one party hung up the call, a [`<Hangup>`](../../bxml/verbs/hangup.md) verb was executed, or there was no more BXML to execute; it indicates that the call ended normally.
 - `busy`: the callee was busy.
 - `timeout`: the call wasn't answered before the `callTimeout` was reached.
-- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `cancel`: the call was cancelled by its originator while it was ringing.
 - `rejected`: the call was rejected by the callee.
-- `callback-error`: a BXML callback couldn't be delivered.
-- `invalid-bxml`: an invalid bxml was tried to be played in the call.
-- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
-- `account-limit`: the rate limits on the account were reached.
-- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `callback-error`: a BXML callback couldn't be delivered to your callback server.
+- `invalid-bxml`: invalid BXML was returned in response to a callback.
+- `application-error`: an unsupported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the account rate limits were reached.
+- `node-capacity-exceeded`: the system maximum capacity was reached.
 - `error`: some error not described in any of the other causes happened on the call.
 - `unknown`: some unknown error happened on the call.
+
+Note: this list is not exhaustive and other values can appear in the future.
 
 ### Expected response
 ```http
@@ -35,10 +37,10 @@ HTTP/1.1 204
 | startTime     | Time the call was started, in ISO 8601 format. |
 | answerTime    | (optional) Time the call was answered, in ISO 8601 format. |
 | endTime       | Time the call ended, in ISO 8601 format. |
-| cause         | Reason the call ended<br> `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
-| errorMessage | (optional) Text explaining the reason that caused the call to be ended in case of errors. |
-| errorId      | (optional) Bandwidth internal id that references the error event. |
-| tag          | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null. |
+| cause         | Reason the call ended. See above for possible values. |
+| errorMessage  | (optional) Text explaining the reason that caused the call to be ended in case of errors. |
+| errorId       | (optional) Bandwidth internal id that references the error event. |
+| tag           | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null. |
 
 {% common %}
 

--- a/voice/bxml/callbacks/disconnect.md
+++ b/voice/bxml/callbacks/disconnect.md
@@ -1,6 +1,19 @@
 {% method %}
 ## Disconnect Event
-The Disconnect event is fired when a call ends, for any reason.
+
+The Disconnect event is fired when a call ends, for any reason. The `cause` for a disconnect event on a call can be:
+- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `busy`: the callee was busy.
+- `timeout`: the call wasn't answered before the `callTimeout` was reached.
+- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `rejected`: the call was rejected by the callee.
+- `callback-error`: a BXML callback couldn't be delivered.
+- `invalid-bxml`: an invalid bxml was tried to be played in the call.
+- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the rate limits on the account were reached.
+- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `error`: some error not described in any of the other causes happened on the call.
+- `unknown`: some unknown error happened on the call.
 
 ### Expected response
 ```http
@@ -9,23 +22,23 @@ HTTP/1.1 204
 
 ### Properties
 
-| Property     | Description                                                                                                                         |
-|:----------   |:------------------------------------------------------------------------------------------------------------------------------------|
-| eventType    | The event type, value is `disconnect`                                                                                               |
-| accountId     | The user account associated with the call.                                                                                          |
-| applicationId | The id of the application associated with the call.                                                                                 |
-| to           | The phone number that received the call, in E.164 format (e.g. +15555555555).                                                       |
-| from         | The phone number that made the call, in E.164 format (e.g. +15555555555).                                                           |
-| direction    | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes.                                   |
-| callId       | The call id associated with the event.                                                                                              |
-| callUrl      | The URL of the call associated with the event.                                                                                      |
-| startTime    | Time the call was started, in ISO 8601 format.                                                                                      |
-| answerTime   | (optional) Time the call was answered, in ISO 8601 format.                                                                          |
-| endTime      | Time the call ended, in ISO 8601 format.                                                                                            |
-| cause        | Reason the call ended<br> `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. `hangup` indicates the call has ended normally. |
-| errorMessage | (optional) Text explaining the reason that caused the call to be ended in case of errors.                                           |
-| errorId      | (optional) Bandwidth internal id that references the error event.                                                                   |
-| tag          | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null.                     |
+| Property      | Description |
+|:----------    |:------------|
+| eventType     | The event type, value is `disconnect`. |
+| accountId     | The user account associated with the call. |
+| applicationId | The id of the application associated with the call. |
+| to            | The phone number that received the call, in E.164 format (e.g. +15555555555). |
+| from          | The phone number that made the call, in E.164 format (e.g. +15555555555). |
+| direction     | The direction of the call. Either `inbound` or `outbound`. The direction of a call never changes. |
+| callId        | The call id associated with the event. |
+| callUrl       | The URL of the call associated with the event. |
+| startTime     | Time the call was started, in ISO 8601 format. |
+| answerTime    | (optional) Time the call was answered, in ISO 8601 format. |
+| endTime       | Time the call ended, in ISO 8601 format. |
+| cause         | Reason the call ended<br> `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
+| errorMessage | (optional) Text explaining the reason that caused the call to be ended in case of errors. |
+| errorId      | (optional) Bandwidth internal id that references the error event. |
+| tag          | (optional) The `tag`  specified on call creation. If no `tag` was specified or it was previously cleared, null. |
 
 {% common %}
 

--- a/voice/bxml/callbacks/transferComplete.md
+++ b/voice/bxml/callbacks/transferComplete.md
@@ -5,18 +5,20 @@ In a simultaneous ringing scenario, only one B-leg succeeds and this event corre
 If none of the calls were answered, the `transferComplete` event corresponds to one of the legs.
 
 The `cause` for a `transferComplete` event on a call can be:
-- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `hangup`: one party hung up the call, a [`<Hangup>`](../../bxml/verbs/hangup.md) verb was executed, or there was no more BXML to execute; it indicates that the call ended normally.
 - `busy`: the callee was busy.
 - `timeout`: the call wasn't answered before the `callTimeout` was reached.
-- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `cancel`: the call was cancelled by its originator while it was ringing.
 - `rejected`: the call was rejected by the callee.
-- `callback-error`: a BXML callback couldn't be delivered.
-- `invalid-bxml`: an invalid bxml was tried to be played in the call.
-- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
-- `account-limit`: the rate limits on the account were reached.
-- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `callback-error`: a BXML callback couldn't be delivered to your callback server.
+- `invalid-bxml`: invalid BXML was returned in response to a callback.
+- `application-error`: an unsupported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the account rate limits were reached.
+- `node-capacity-exceeded`: the system maximum capacity was reached.
 - `error`: some error not described in any of the other causes happened on the call.
 - `unknown`: some unknown error happened on the call.
+
+Note: this list is not exhaustive and other values can appear in the future.
 
 ### Expected response
 ```http
@@ -45,7 +47,7 @@ Content-Type: application/xml; charset=utf-8
 | tag              | The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                                     |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                                       |
-| cause            | Reason the call ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
+| cause            | Reason the call ended. See above for possible values. |
 | errorMessage     | Text explaining the reason that caused the call to be ended in case of errors.                                                        |
 | errorId          | Bandwidth internal id that references the error event.                                                                                |
 

--- a/voice/bxml/callbacks/transferComplete.md
+++ b/voice/bxml/callbacks/transferComplete.md
@@ -4,6 +4,20 @@ This event is sent to the `transferCompleteUrl` of the A-leg's `<Transfer>` verb
 In a simultaneous ringing scenario, only one B-leg succeeds and this event corresponds to that successful leg.
 If none of the calls were answered, the `transferComplete` event corresponds to one of the legs.
 
+The `cause` for a `transferComplete` event on a call can be:
+- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `busy`: the callee was busy.
+- `timeout`: the call wasn't answered before the `callTimeout` was reached.
+- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `rejected`: the call was rejected by the callee.
+- `callback-error`: a BXML callback couldn't be delivered.
+- `invalid-bxml`: an invalid bxml was tried to be played in the call.
+- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the rate limits on the account were reached.
+- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `error`: some error not described in any of the other causes happened on the call.
+- `unknown`: some unknown error happened on the call.
+
 ### Expected response
 ```http
 HTTP/1.1 200
@@ -31,7 +45,7 @@ Content-Type: application/xml; charset=utf-8
 | tag              | The `tag` specified earlier in the call. If no `tag` was specified or it was previously cleared, null.                                |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                                     |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                                       |
-| cause            | Reason the call ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. `hangup` indicates the call has ended normally. |
+| cause            | Reason the call ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
 | errorMessage     | Text explaining the reason that caused the call to be ended in case of errors.                                                        |
 | errorId          | Bandwidth internal id that references the error event.                                                                                |
 

--- a/voice/bxml/callbacks/transferDisconnect.md
+++ b/voice/bxml/callbacks/transferDisconnect.md
@@ -4,6 +4,20 @@ This event is sent to the `transferDisconnectUrl` of each `<PhoneNumber>` tag wh
 The event is sent in the normal case, when the transferred leg is answered and later hung up, but is also sent if the new leg
 was never answered in the first place, if it was rejected, and if the original call leg hung up before the transferred leg.
 
+The `cause` for a `transferDisconnect` event on a call can be:
+- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `busy`: the callee was busy.
+- `timeout`: the call wasn't answered before the `callTimeout` was reached.
+- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `rejected`: the call was rejected by the callee.
+- `callback-error`: a BXML callback couldn't be delivered.
+- `invalid-bxml`: an invalid bxml was tried to be played in the call.
+- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the rate limits on the account were reached.
+- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `error`: some error not described in any of the other causes happened on the call.
+- `unknown`: some unknown error happened on the call.
+
 ### Expected response
 ```http
 HTTP/1.1 204
@@ -25,7 +39,7 @@ HTTP/1.1 204
 | endTime          | Time the transferred leg ended, in ISO 8601 format.                                                                                                                                                                                       |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                                                                                                                                         |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                                                                                                                                           |
-| cause            | Reason the transferred leg ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. `hangup` indicates the call has ended normally. |
+| cause            | Reason the transferred leg ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
 | errorMessage     | Text explaining the reason that caused the transferred leg to be ended in case of errors.                                                                                                                                                 |
 | errorId          | Bandwidth internal id that references the error event.                                                                                                                                                                                    |
 

--- a/voice/bxml/callbacks/transferDisconnect.md
+++ b/voice/bxml/callbacks/transferDisconnect.md
@@ -5,18 +5,20 @@ The event is sent in the normal case, when the transferred leg is answered and l
 was never answered in the first place, if it was rejected, and if the original call leg hung up before the transferred leg.
 
 The `cause` for a `transferDisconnect` event on a call can be:
-- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `hangup`: one party hung up the call, a [`<Hangup>`](../../bxml/verbs/hangup.md) verb was executed, or there was no more BXML to execute; it indicates that the call ended normally.
 - `busy`: the callee was busy.
 - `timeout`: the call wasn't answered before the `callTimeout` was reached.
-- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `cancel`: the call was cancelled by its originator while it was ringing.
 - `rejected`: the call was rejected by the callee.
-- `callback-error`: a BXML callback couldn't be delivered.
-- `invalid-bxml`: an invalid bxml was tried to be played in the call.
-- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
-- `account-limit`: the rate limits on the account were reached.
-- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `callback-error`: a BXML callback couldn't be delivered to your callback server.
+- `invalid-bxml`: invalid BXML was returned in response to a callback.
+- `application-error`: an unsupported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the account rate limits were reached.
+- `node-capacity-exceeded`: the system maximum capacity was reached.
 - `error`: some error not described in any of the other causes happened on the call.
 - `unknown`: some unknown error happened on the call.
+
+Note: this list is not exhaustive and other values can appear in the future.
 
 ### Expected response
 ```http
@@ -39,7 +41,7 @@ HTTP/1.1 204
 | endTime          | Time the transferred leg ended, in ISO 8601 format.                                                                                                                                                                                       |
 | transferCallerId | The phone number used as the `from` field of the B-leg call, in E.164 format (e.g. +15555555555).                                                                                                                                         |
 | transferTo       | The phone number used as the `to` field of the B-leg call, in E.164 format (e.g. +15555555555).                                                                                                                                           |
-| cause            | Reason the transferred leg ended - `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
+| cause            | Reason the transferred leg ended. See above for possible values. |
 | errorMessage     | Text explaining the reason that caused the transferred leg to be ended in case of errors.                                                                                                                                                 |
 | errorId          | Bandwidth internal id that references the error event.                                                                                                                                                                                    |
 

--- a/voice/methods/calls/getCallsCallId.md
+++ b/voice/methods/calls/getCallsCallId.md
@@ -7,18 +7,20 @@ Retrieve the current state of a specific call.
 retrieve information for a call that is older than 7 days, you will get an HTTP 404 response.
 
 The `disconnectCause` for a call can be:
-- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `hangup`: one party hung up the call, a [`<Hangup>`](../../bxml/verbs/hangup.md) verb was executed, or there was no more BXML to execute; it indicates that the call ended normally.
 - `busy`: the callee was busy.
 - `timeout`: the call wasn't answered before the `callTimeout` was reached.
-- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `cancel`: the call was cancelled by its originator while it was ringing.
 - `rejected`: the call was rejected by the callee.
-- `callback-error`: a BXML callback couldn't be delivered.
-- `invalid-bxml`: an invalid bxml was tried to be played in the call.
-- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
-- `account-limit`: the rate limits on the account were reached.
-- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `callback-error`: a BXML callback couldn't be delivered to your callback server.
+- `invalid-bxml`: invalid BXML was returned in response to a callback.
+- `application-error`: an unsupported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the account rate limits were reached.
+- `node-capacity-exceeded`: the system maximum capacity was reached.
 - `error`: some error not described in any of the other causes happened on the call.
 - `unknown`: some unknown error happened on the call.
+
+Note: this list is not exhaustive and other values can appear in the future.
 
 ### Request URL
 
@@ -51,7 +53,7 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 | startTime       | The time the call was initiated, in ISO 8601 format.                                                                     |
 | answerTime      | (optional) Populated once the call has been answered, with the time in ISO 8601 format.                                  |
 | endTime         | (optional) Populated once the call has ended, with the time in ISO 8601 format.                                          |
-| disconnectCause | (optional) Populated once the call has ended, with the reason the call ended: `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
+| disconnectCause | (optional) Populated once the call has ended, with the reason the call ended. See above for possible values. |
 | errorMessage    | (optional) Populated only if the call ended with an error, with a text explaining the reason.                            |
 | errorId         | (optional) Populated only if the call ended with an error, with a Bandwidth internal id that references the error event. |
 | lastUpdate      | The last time the call had a state update, in ISO 8601 format.                                                           |

--- a/voice/methods/calls/getCallsCallId.md
+++ b/voice/methods/calls/getCallsCallId.md
@@ -6,6 +6,20 @@ Retrieve the current state of a specific call.
 **Note**: Call information is kept for 7 days after the calls are hung up. If you attempt to
 retrieve information for a call that is older than 7 days, you will get an HTTP 404 response.
 
+The `disconnectCause` for a call can be:
+- `hangup`: there was no more BXML to execute in it; it indicates that the call ended normally.
+- `busy`: the callee was busy.
+- `timeout`: the call wasn't answered before the `callTimeout` was reached.
+- `cancel`: while the call was ringing, it was cancelled by its originator.
+- `rejected`: the call was rejected by the callee.
+- `callback-error`: a BXML callback couldn't be delivered.
+- `invalid-bxml`: an invalid bxml was tried to be played in the call.
+- `application-error`: some non-supported action was tried on the call, e.g. trying to play a .ogg audio.
+- `account-limit`: the rate limits on the account were reached.
+- `node-capacity-exceeded`: the system itself reached its maximum capacity.
+- `error`: some error not described in any of the other causes happened on the call.
+- `unknown`: some unknown error happened on the call.
+
 ### Request URL
 
 <code class="get">GET</code>`https://voice.bandwidth.com/api/v2/accounts/{accountId}/calls/{callId}`
@@ -37,7 +51,7 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 | startTime       | The time the call was initiated, in ISO 8601 format.                                                                     |
 | answerTime      | (optional) Populated once the call has been answered, with the time in ISO 8601 format.                                  |
 | endTime         | (optional) Populated once the call has ended, with the time in ISO 8601 format.                                          |
-| disconnectCause | (optional) Populated once the call has ended, with the reason the call ended: `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`.<br>`hangup` indicates the call ended normally. |
+| disconnectCause | (optional) Populated once the call has ended, with the reason the call ended: `busy`, `timeout`, `hangup`, `cancel`, `rejected`, `callback-error`, `invalid-bxml`, `account-limit`, `node-capacity-exceeded`, `error`, `unknown` or `application-error`. |
 | errorMessage    | (optional) Populated only if the call ended with an error, with a text explaining the reason.                            |
 | errorId         | (optional) Populated only if the call ended with an error, with a Bandwidth internal id that references the error event. |
 | lastUpdate      | The last time the call had a state update, in ISO 8601 format.                                                           |


### PR DESCRIPTION
## Brief Summary of changes

- Clarify the disconnect causes in the `disconnect`, `transferComplete` and `transferDisconnect` events