### PR TITLE
EDGE-478 Update WebRTC API Documentation for participant stream alias…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 bower_components
 #Ignore IDEA files
 /.idea
+*.iml
 
 # Ignore all logfiles and tempfiles.
 *.log

--- a/webrtc/methods/participants/createParticipant.md
+++ b/webrtc/methods/participants/createParticipant.md
@@ -25,8 +25,7 @@ You should not include sensitive or personally-identifiable information in any t
 | Parameter                   | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
 | callbackUrl                 | Full callback url to use for notifications about this participant                                 
-| publishPermissions          | Defines if this participant can publish audio or video                                            
-| subscriptions               | Subscription information for this participant                                                     
+| publishPermissions          | Defines the types of media this participant can publish. Accepted values: `AUDIO`,`VIDEO`                                                                                           
 | tag                         | User defined tag to associate with the participant                                                
 
 
@@ -55,17 +54,6 @@ curl -X POST
     "VIDEO",
     "AUDIO"
   ],
-  "subscriptions": {
-    "sessionId": "d8886aad-b956-4e1b-b2f4-d7c9f8162772",
-    "participants": [
-      {
-        "participantId": "568749d5-04d5-483d-adf5-deac7dd3d521"
-      },
-      {
-        "participantId": "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7"
-      }
-    ]
-  },
   "tag": "participant1"
 }'
 ```

--- a/webrtc/methods/participants/deleteParticipant.md
+++ b/webrtc/methods/participants/deleteParticipant.md
@@ -31,7 +31,6 @@ curl -X DELETE
 
 ```json
 
-}
 ```
 
 ### Potential Error Responses

--- a/webrtc/methods/participants/getParticipant.md
+++ b/webrtc/methods/participants/getParticipant.md
@@ -20,7 +20,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | callbackUrl                 | Full callback url to use for notifications about this participant                                 
 | publishPermissions          | Defines if this participant can publish audio or video                                            
 | sessions                    | List of session ids this participant is associated with                                           
-| subscriptions               | Subscription information for this participant, which lists the sessions and IDs of Participants publishing media                                                   
+| subscriptions               | Subscription information for this participant, which lists the sessions and IDs of Participants publishing media
 | tag                         | User defined tag to associate with the participant                                                
 
 

--- a/webrtc/methods/participants/getParticipant.md
+++ b/webrtc/methods/participants/getParticipant.md
@@ -20,7 +20,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | callbackUrl                 | Full callback url to use for notifications about this participant                                 
 | publishPermissions          | Defines if this participant can publish audio or video                                            
 | sessions                    | List of session ids this participant is associated with                                           
-| subscriptions               | Subscription information for this participant                                                     
+| subscriptions               | Subscription information for this participant, which lists the sessions and IDs of Participants publishing media                                                   
 | tag                         | User defined tag to associate with the participant                                                
 
 
@@ -55,10 +55,10 @@ curl -X GET
       "participants"        : [
           {
               "participantId"       : "568749d5-04d5-483d-adf5-deac7dd3d521"
-         } ,
+          },
           {
               "participantId"       : "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7"
-         } 
+          } 
      ]
  },
   "tag"                 : "participant1"

--- a/webrtc/methods/sessions/addParticipantToSession.md
+++ b/webrtc/methods/sessions/addParticipantToSession.md
@@ -2,7 +2,7 @@
 
 ## Add a participant to a session
 
-Subscriptions can optionally be provided as part of this call
+Subscriptions can optionally be provided as part of this call.
 
 
 ### Request URL
@@ -18,7 +18,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | Parameter                   | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
 | sessionId                   | Session the subscriptions are associated with.                                                    
-| participants                | Subset of participants to subscribe to in the session. Optional.                                  
+| participants                | IDs of Participants publishing media to be subscribed to, optionally including a subset of stream aliases. Optional.                                
 
 
 
@@ -37,8 +37,13 @@ curl -X PUT
 {
   "sessionId": "d8886aad-b956-4e1b-b2f4-d7c9f8162772",
   "participants": [
-    "568749d5-04d5-483d-adf5-deac7dd3d521",
-    "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7"
+    {
+        "participantId": "568749d5-04d5-483d-adf5-deac7dd3d521"
+    },
+    {
+        "participantId": "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7",
+        "streamAliases": ["microphone1", "microphone2"]
+    }
   ]
 }'
 ```
@@ -47,7 +52,6 @@ curl -X PUT
 
 ```json
 
-}
 ```
 
 ### Potential Error Responses

--- a/webrtc/methods/sessions/addParticipantToSession.md
+++ b/webrtc/methods/sessions/addParticipantToSession.md
@@ -17,7 +17,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 ### Request Body Parameters
 | Parameter                   | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
-| sessionId                   | Session the subscriptions are associated with.                                                    
+| sessionId                   | Session the subscriptions are associated with.
 | participants                | IDs of Participants publishing media to be subscribed to, optionally including a subset of stream aliases. Optional.                                
 
 

--- a/webrtc/methods/sessions/createSession.md
+++ b/webrtc/methods/sessions/createSession.md
@@ -30,8 +30,7 @@ You should not include sensitive or personally-identifiable information in any t
 ### Response Attributes
 | Property                    | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
-| id                          | Unique id of the session                                                                          
-| participants                | The list of participants associated with this session                                             
+| id                          | Unique id of the session                                                                                                                    
 | tag                         | User defined tag to associate with the session                                                    
 
 
@@ -57,10 +56,6 @@ curl -X POST
 ```json
 {
   "id"                  : "75c21163-e110-41bc-bd76-1bb428ec85d5",
-  "participants"        : [
-      "c0c0dcfd-4ce4-4752-a8d9-b6ddeb72bead",
-      "320e2af6-13ec-498d-8b51-daba52c37853"
- ],
   "tag"                 : "session1"
 }
 ```

--- a/webrtc/methods/sessions/deleteSession.md
+++ b/webrtc/methods/sessions/deleteSession.md
@@ -31,7 +31,6 @@ curl -X DELETE
 
 ```json
 
-}
 ```
 
 ### Potential Error Responses

--- a/webrtc/methods/sessions/getParticipantSubscriptions.md
+++ b/webrtc/methods/sessions/getParticipantSubscriptions.md
@@ -17,7 +17,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | Property                    | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
 | sessionId                   | Session the subscriptions are associated with.                                                    
-| participants                | Subset of participants to subscribe to in the session. Optional.                                  
+| participants                | IDs of Participants publishing media, optionally including a subset of stream aliases.                                  
 
 
 
@@ -39,9 +39,14 @@ curl -X GET
 {
   "sessionId"           : "d8886aad-b956-4e1b-b2f4-d7c9f8162772",
   "participants"        : [
-      "568749d5-04d5-483d-adf5-deac7dd3d521",
-      "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7"
- ]
+      {
+          "participantId"       : "568749d5-04d5-483d-adf5-deac7dd3d521"
+      },
+      {
+          "participantId"       : "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7",
+          "streamAliases"       : ["microphone1", "microphone2"]
+      } 
+  ]
 }
 ```
 

--- a/webrtc/methods/sessions/getSession.md
+++ b/webrtc/methods/sessions/getSession.md
@@ -16,8 +16,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 ### Response Attributes
 | Property                    | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
-| id                          | Unique id of the session                                                                          
-| participants                | The list of participants associated with this session                                             
+| id                          | Unique id of the session                                                                                                                     
 | tag                         | User defined tag to associate with the session                                                    
 
 
@@ -39,10 +38,6 @@ curl -X GET
 ```json
 {
   "id"                  : "75c21163-e110-41bc-bd76-1bb428ec85d5",
-  "participants"        : [
-      "c0c0dcfd-4ce4-4752-a8d9-b6ddeb72bead",
-      "320e2af6-13ec-498d-8b51-daba52c37853"
- ],
   "tag"                 : "session1"
 }
 ```

--- a/webrtc/methods/sessions/removeParticipantFromSession.md
+++ b/webrtc/methods/sessions/removeParticipantFromSession.md
@@ -33,7 +33,6 @@ curl -X DELETE
 
 ```json
 
-}
 ```
 
 ### Potential Error Responses

--- a/webrtc/methods/sessions/updateParticipantSubscriptions.md
+++ b/webrtc/methods/sessions/updateParticipantSubscriptions.md
@@ -2,7 +2,7 @@
 
 ## Update a participant's subscriptions
 
-This is a full update that will replace the participant's subscriptions. First call `getParticipantSubscriptions` if you need the current subscriptions. Call this function with no `Subscriptions` object to remove all subscriptions
+This is a full update that will replace the participant's subscriptions. First call `getParticipantSubscriptions` if you need the current subscriptions. Call this endpoint with no `Subscriptions` object to remove all subscriptions
 
 
 ### Request URL
@@ -18,7 +18,7 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | Parameter                   | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
 | sessionId                   | Session the subscriptions are associated with.                                                    
-| participants                | Subset of participants to subscribe to in the session. Optional.                                  
+| participants                | IDs of Participants publishing media to be subscribed to, optionally including a subset of stream aliases. Optional.                                  
 
 
 
@@ -37,8 +37,13 @@ curl -X PUT
 {
   "sessionId": "d8886aad-b956-4e1b-b2f4-d7c9f8162772",
   "participants": [
-    "568749d5-04d5-483d-adf5-deac7dd3d521",
-    "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7"
+    {
+        "participantId": "568749d5-04d5-483d-adf5-deac7dd3d521"
+    },
+    {
+        "participantId": "0275e47f-dd21-4cf0-a1e1-dfdc719e73a7",
+        "streamAliases": ["microphone1", "microphone2"]
+    }
   ]
 }'
 ```


### PR DESCRIPTION
…es, other updates

## Brief Summary of changes

Updated the WebRTC API Methods to match the actual implementation, particularly around Participant stream aliases.

I tested by issuing curl commands to the various endpoints and comparing the responses with the docs