### PR TITLE
STIR/SHAKEN details for HTTP Voice

### DIFF
--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -29,7 +29,7 @@ Content-Type: application/xml; charset=utf-8
 | startTime         | Time the call was started, in ISO 8601 format. |
 | [diversion](#diversion-properties) | (optional) Information from the most recent `Diversion` header, if any. |
 | identity			| (optional) The value of the `Identity` header from the inbound invite request. Only present if the account is configured to forward this header. |
-| [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
+| [stirShaken](#stirshaken-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
 
 #### Diversion properties
 
@@ -46,9 +46,9 @@ The `Diversion` header is parsed into a JSON object. Note that the attributes va
 | counter 	| The number of diversions that have occurred.
 | limit 	| The maximum number of diversions allowed for this session.
 
-#### PAI properties
+#### STIR/SHAKEN properties
 
-The Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is included in the Initiate event `pai` property as follows.
+The Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is included in the Initiate event `stirShaken` property as follows.
 
 | Property          | Description |
 |:------------------|:------------|

--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -28,6 +28,20 @@ Content-Type: application/xml; charset=utf-8
 | callUrl           | The URL of the call associated with the event. |
 | startTime         | Time the call was started, in ISO 8601 format. |
 | diversion         | (optional) Information from the most recent Diversion header, if any. If present, the value will be a sub-object like `"diversion": {"param1": "value1", "param2": "value2"}`.<br>Each diversion parameter gets its own key in the JSON structure, and the keys present and their values will vary depending on the parameters received in the SIP header.<br><br>**Common Parameters**<br>- `origTo`: always present. Indicates the last telephone number that the call was diverted from.<br><br>**Note**: for all of the following keys, the values listed are common values, but this list is not exhaustive. Your application **must** be tolerant of unlisted keys and unlisted values of those keys.<br>- `reason`: The reason for the diversion. Common values: `unknown`, `user-busy`, `no-answer`, `unavailable`, `unconditional`, `time-of-day`, `do-not-disturb`, `deflection`, `follow-me`, `out-of-service`, `away`<br>- `screen`: `no` if the number was provided by the user, `yes` if the number was provided by the network<br>- `privacy`: `off` or `full`<br>- `counter`: the number of diversions that have occurred<br>- `limit`: The maximum number of diversions allowed for this session |
+| identity			| (optional) The value of the `Identity` header from the inbound invite request. Only present if the account is configured to forward this header. |
+| pai				| (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
+
+#### PAI properties
+
+The Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is included in the Initiate event `pai` property as follows.
+
+| Property          | Description |
+|:------------------|:------------|
+| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` or `TN-Verification-Failed`. |
+| attestationIndicator | (optional) The attestation level verified by Bandwidth. Possible values are `A` (full), `B` (partial) or `C` (gateway). |
+| originatingId | (optional) A unique origination identifier. |
+
+More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
 
 {% common %}
 

--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -29,7 +29,7 @@ Content-Type: application/xml; charset=utf-8
 | startTime         | Time the call was started, in ISO 8601 format. |
 | diversion         | (optional) Information from the most recent Diversion header, if any. If present, the value will be a sub-object like `"diversion": {"param1": "value1", "param2": "value2"}`.<br>Each diversion parameter gets its own key in the JSON structure, and the keys present and their values will vary depending on the parameters received in the SIP header.<br><br>**Common Parameters**<br>- `origTo`: always present. Indicates the last telephone number that the call was diverted from.<br><br>**Note**: for all of the following keys, the values listed are common values, but this list is not exhaustive. Your application **must** be tolerant of unlisted keys and unlisted values of those keys.<br>- `reason`: The reason for the diversion. Common values: `unknown`, `user-busy`, `no-answer`, `unavailable`, `unconditional`, `time-of-day`, `do-not-disturb`, `deflection`, `follow-me`, `out-of-service`, `away`<br>- `screen`: `no` if the number was provided by the user, `yes` if the number was provided by the network<br>- `privacy`: `off` or `full`<br>- `counter`: the number of diversions that have occurred<br>- `limit`: The maximum number of diversions allowed for this session |
 | identity			| (optional) The value of the `Identity` header from the inbound invite request. Only present if the account is configured to forward this header. |
-| pai				| (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
+| [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
 
 #### PAI properties
 

--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -31,18 +31,6 @@ Content-Type: application/xml; charset=utf-8
 | identity			| (optional) The value of the `Identity` header from the inbound invite request. Only present if the account is configured to forward this header. |
 | [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
 
-#### PAI properties
-
-The Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is included in the Initiate event `pai` property as follows.
-
-| Property          | Description |
-|:------------------|:------------|
-| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` or `TN-Verification-Failed`. |
-| attestationIndicator | (optional) The attestation level verified by Bandwidth. Possible values are `A` (full), `B` (partial) or `C` (gateway). |
-| originatingId | (optional) A unique origination identifier. |
-
-More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
-
 #### Diversion properties
 
 The `Diversion` header is parsed into a JSON object. Note that the attributes vary depending on the parameters received in the SIP header. Some common attributes and values are listed below.
@@ -57,6 +45,18 @@ The `Diversion` header is parsed into a JSON object. Note that the attributes va
 | privacy 	| `off` or `full`.
 | counter 	| The number of diversions that have occurred.
 | limit 	| The maximum number of diversions allowed for this session.
+
+#### PAI properties
+
+The Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is included in the Initiate event `pai` property as follows.
+
+| Property          | Description |
+|:------------------|:------------|
+| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` or `TN-Verification-Failed`. |
+| attestationIndicator | (optional) The attestation level verified by Bandwidth. Possible values are `A` (full), `B` (partial) or `C` (gateway). |
+| originatingId | (optional) A unique origination identifier. |
+
+More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
 
 {% common %}
 

--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -27,7 +27,7 @@ Content-Type: application/xml; charset=utf-8
 | callId            | The call id associated with the event. |
 | callUrl           | The URL of the call associated with the event. |
 | startTime         | Time the call was started, in ISO 8601 format. |
-| diversion         | (optional) Information from the most recent Diversion header, if any. If present, the value will be a sub-object like `"diversion": {"param1": "value1", "param2": "value2"}`.<br>Each diversion parameter gets its own key in the JSON structure, and the keys present and their values will vary depending on the parameters received in the SIP header.<br><br>**Common Parameters**<br>- `origTo`: always present. Indicates the last telephone number that the call was diverted from.<br><br>**Note**: for all of the following keys, the values listed are common values, but this list is not exhaustive. Your application **must** be tolerant of unlisted keys and unlisted values of those keys.<br>- `reason`: The reason for the diversion. Common values: `unknown`, `user-busy`, `no-answer`, `unavailable`, `unconditional`, `time-of-day`, `do-not-disturb`, `deflection`, `follow-me`, `out-of-service`, `away`<br>- `screen`: `no` if the number was provided by the user, `yes` if the number was provided by the network<br>- `privacy`: `off` or `full`<br>- `counter`: the number of diversions that have occurred<br>- `limit`: The maximum number of diversions allowed for this session |
+| [diversion](#diversion-properties) | (optional) Information from the most recent `Diversion` header, if any. |
 | identity			| (optional) The value of the `Identity` header from the inbound invite request. Only present if the account is configured to forward this header. |
 | [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. |
 
@@ -42,6 +42,21 @@ The Bandwidth STIR/SHAKEN implementation will verify the information provided in
 | originatingId | (optional) A unique origination identifier. |
 
 More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
+
+#### Diversion properties
+
+The `Diversion` header is parsed into a JSON object. Note that the attributes vary depending on the parameters received in the SIP header. Some common attributes and values are listed below.
+
+**Note:** it is not an exhaustive list. Your application must be tolerant to unlisted attributes and values.
+
+| Property  | Description |
+|:----------|:------------|
+| origTo 	| Indicates the last telephone number that the call was diverted from. This attribute is always present.
+| reason 	| The diversion reason. Common values: `unknown`, `user-busy`, `no-answer`, `unavailable`, `unconditional`, `time-of-day`, `do-not-disturb`, `deflection`, `follow-me`, `out-of-service`, `away`.
+| screen 	| `no` if the number was provided by the user, `yes` if the number was provided by the network.
+| privacy 	| `off` or `full`.
+| counter 	| The number of diversions that have occurred.
+| limit 	| The maximum number of diversions allowed for this session.
 
 {% common %}
 

--- a/voice/bxml/callbacks/initiate.md
+++ b/voice/bxml/callbacks/initiate.md
@@ -52,7 +52,7 @@ The Bandwidth STIR/SHAKEN implementation will verify the information provided in
 
 | Property          | Description |
 |:------------------|:------------|
-| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` or `TN-Verification-Failed`. |
+| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` and `TN-Verification-Failed`. |
 | attestationIndicator | (optional) The attestation level verified by Bandwidth. Possible values are `A` (full), `B` (partial) or `C` (gateway). |
 | originatingId | (optional) A unique origination identifier. |
 

--- a/voice/methods/calls/getCallsCallId.md
+++ b/voice/methods/calls/getCallsCallId.md
@@ -59,7 +59,7 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 | errorId         | (optional) Populated only if the call ended with an error, with a Bandwidth internal id that references the error event. |
 | lastUpdate      | The last time the call had a state update, in ISO 8601 format.                                                           |
 | identity        | (optional) The value of the `Identity` header from the inbound invite request. Only present for inbound calls and if the account is configured to forward this header. |
-| pai             | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. Only present for inbound calls. |
+| [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. Only present for inbound calls. |
 {% common %}
 
 #### PAI properties

--- a/voice/methods/calls/getCallsCallId.md
+++ b/voice/methods/calls/getCallsCallId.md
@@ -59,12 +59,11 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 | errorId         | (optional) Populated only if the call ended with an error, with a Bandwidth internal id that references the error event. |
 | lastUpdate      | The last time the call had a state update, in ISO 8601 format.                                                           |
 | identity        | (optional) The value of the `Identity` header from the inbound invite request. Only present for inbound calls and if the account is configured to forward this header. |
-| [pai](#pai-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. Only present for inbound calls. |
-{% common %}
+| [stirShaken](#stirshaken-properties) | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. Only present for inbound calls. |
 
-#### PAI properties
+#### STIR/SHAKEN properties
 
-For inbound calls, the Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is stored in the call state `pai` property as follows.
+For inbound calls, the Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is stored in the call state `stirShaken` property as follows.
 
 | Property          | Description |
 |:------------------|:------------|
@@ -73,6 +72,8 @@ For inbound calls, the Bandwidth STIR/SHAKEN implementation will verify the info
 | originatingId | (optional) A unique origination identifier. |
 
 More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
+
+{% common %}
 
 ### Example 1 of 1: Retrieve information about a specific call
 

--- a/voice/methods/calls/getCallsCallId.md
+++ b/voice/methods/calls/getCallsCallId.md
@@ -58,8 +58,21 @@ Bandwidth's Voice API leverages Basic Authentication with your Dashboard API Cre
 | errorMessage    | (optional) Populated only if the call ended with an error, with a text explaining the reason.                            |
 | errorId         | (optional) Populated only if the call ended with an error, with a Bandwidth internal id that references the error event. |
 | lastUpdate      | The last time the call had a state update, in ISO 8601 format.                                                           |
-
+| identity        | (optional) The value of the `Identity` header from the inbound invite request. Only present for inbound calls and if the account is configured to forward this header. |
+| pai             | (optional) The verification status provided by Bandwidth STIR/SHAKEN implementation. Only present for inbound calls. |
 {% common %}
+
+#### PAI properties
+
+For inbound calls, the Bandwidth STIR/SHAKEN implementation will verify the information provided in the inbound invite request `Identity` header. The verification status is stored in the call state `pai` property as follows.
+
+| Property          | Description |
+|:------------------|:------------|
+| verstat | (optional) The verification status indicating whether the verification was successful or not. Possible values are `TN-Verification-Passed` or `TN-Verification-Failed`. |
+| attestationIndicator | (optional) The attestation level verified by Bandwidth. Possible values are `A` (full), `B` (partial) or `C` (gateway). |
+| originatingId | (optional) A unique origination identifier. |
+
+More information: [Understanding STIR/SHAKEN](https://www.bandwidth.com/regulations/stir-shaken)
 
 ### Example 1 of 1: Retrieve information about a specific call
 


### PR DESCRIPTION
### Changes
- Added `identity` and `pai` attributes in Initiate event and call state properties
- Both pages link to Bandwidth's page about STIR/SHAKEN

### Also
- Extracted `diversion` properties in Initiate event to another table.