### PR TITLE
EDGE-615: fix issue with commas in MFA errors.md

### DIFF
--- a/mfa/errors.md
+++ b/mfa/errors.md
@@ -175,7 +175,7 @@ Content-Type: text/plain;charset=UTF-8
   "to"                       : "+12345678901",
   "applicationId"            : "93de2206-9669-4e07-948d-329f4b722ee2",
   "scope"                    : "2FA",
-  "expirationTimeInMinutes"  : 3
+  "expirationTimeInMinutes"  : 3,
   "code"                     : "1234"
 }
 ```
@@ -219,7 +219,7 @@ Content-Type: text/plain;charset=UTF-8
   "to"                       : "+12345678901",
   "applicationId"            : "93de2206-9669-4e07-948d-329f4b722ee2",
   "scope"                    : "2FA",
-  "expirationTimeInMinutes"  : 3
+  "expirationTimeInMinutes"  : 3,
   "code"                     : "1234"
 }
 ```


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes
After MFA document changes, I realized I had forgotten a comma in the example JSON. This will help the UI render it a little more user-friendly. See example below
![Screen Shot 2021-02-05 at 10 21 47 AM](https://user-images.githubusercontent.com/74555015/107052706-f866a380-679b-11eb-9788-e875636b0727.png)

