### PR TITLE
update GET /messages example base64 auth to be encoded dashboard credentials

### DIFF
--- a/messaging/methods/messages/getMessages.md
+++ b/messaging/methods/messages/getMessages.md
@@ -71,7 +71,7 @@ Authentication on this endpoint is <b>NOT</b> done via API token and secret. Ins
 
 ```http
 GET https://messaging.bandwidth.com/api/v2/users/{accountId}/messages?messageId=1589228074636lm4k2je7j7jklbn2 HTTP/1.1
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -108,7 +108,7 @@ Content-Type: application/json
 
 ```http
 GET https://messaging.bandwidth.com/api/v2/users/{accountId}/messages?messageStatus=DLR_EXPIRED HTTP/1.1
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 HTTP/1.1 200 OK
 Content-Type: application/json


### PR DESCRIPTION
Our docs sometimes contradict our own guidance about when to use API tokens in V2 vs when to use dashboard credentials; the `GET /messages` endpoint should use dashboard credentials. This just updates the base64 encoded auth to "username:password" instead of "apiToken:apiToken".

[Based on a chat in slack](https://bandwidth.slack.com/archives/CAE3J9YMS/p1615329021021800?thread_ts=1614977586.137600&cid=CAE3J9YMS)

## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes

