### PR TITLE
MV-4977 Change API token/secret to username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ result = message_controller.create_message(account_id,:body => body)
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {

--- a/guides/accountCredentials.md
+++ b/guides/accountCredentials.md
@@ -28,6 +28,6 @@ Bandwidth provides a 'user-based' permission and authentication scheme. It's rec
 
 ⚠️ The API user is meant to be separate from your Dashboard user and **should not** be used to access the Dashboard.  Further, your Dashboard user **should not** be used to access Bandwidth's APIs.
 
-Unlike the other user types, API users are not required to update their password every 90 days.
+Unlike other user types, an API user is not required to update their password.
 
 <br>

--- a/guides/accountCredentials.md
+++ b/guides/accountCredentials.md
@@ -20,16 +20,14 @@ All of Bandwidth's APIs are protected with Basic Authorization over HTTPS. Basic
 | `password`      | The **password** of your **API Credentials** for the  [Bandwidth Dashboard](https://dashboard.bandwidth.com)                                                       | `correct-horse-battery-staple`                     |
 | `accountId`     | Your unique account **id**.  The `accountId` is used as part of the url to make API requests. <br> Ex: `https://dashboard.bandwidth.com/api/accounts/{accountId}/` | `920012`                                           |
 
-## Creating the API Credentials
+## Creating an API User
 
-Bandwidth provides a 'user-based' permission and authentication scheme. It's recommended to [create a new user](https://support.bandwidth.com/hc/en-us/articles/115007187088-How-to-Create-New-Users-in-the-Bandwidth-Dashboard) with **ONLY** API access and the possible "roles on your account".
+Bandwidth provides a 'user-based' permission and authentication scheme. It's recommended to [create a new user](https://support.bandwidth.com/hc/en-us/articles/115007187088-How-to-Create-New-Users-in-the-Bandwidth-Dashboard) with **ONLY** API access and the necessary roles on your account. The API user can be leveraged to access all of Bandwidth's APIs.
 
-It's worth noting the other user types besides API are forced to update password every 90 days.
+## API User Credentials 
 
-## API Credentials 
+⚠️ The API user is meant to be separate from your Dashboard user and **should not** be used to access the Dashboard.  Further, your Dashboard user **should not** be used to access Bandwidth's APIs.
 
-All of Bandwidth's APIs leverage your API Credentials created specifically for API access.  The API Credential pair must be created as a unique set within Dashboard. Learn more about creating your API Credentials in the [support article](https://support.bandwidth.com/hc/en-us/articles/115007187088-How-to-Create-New-Users-in-the-Bandwidth-Dashboard).
-
-⚠️ The API Credential pair are generally separate from your **Login Username & Password** and **should not** be used to access the dashboard.  Further, your login username and password **should not** be used to access Bandwidth's APIs.
+Unlike the other user types, API users are not required to update their password every 90 days.
 
 <br>

--- a/guides/accountCredentials.md
+++ b/guides/accountCredentials.md
@@ -4,21 +4,21 @@
 
 # Account Credentials {#top}
 
-This guide will cover the different credentials for interacting with Bandwidth's APIs, and how to authenticate on each API.
+This guide will cover the credentials for interacting with Bandwidth's APIs.
 
 ## Basic Authorization
 
-All of Bandwidth's APIs are protected with Basic Authorization over HTTPS. Basic Authorization requires the credential pair to be encoded with [base64](https://en.wikipedia.org/wiki/Base64) as part of the `Authorization` HTTP header.
+All of Bandwidth's APIs are protected with Basic Authorization over HTTPS. Basic Authorization requires the user's `username:password` pair to be encoded with [base64](https://en.wikipedia.org/wiki/Base64) as part of the `Authorization` HTTP header.
 
-⚠️ Username and Passwords are **case sensitive**!
+⚠️ Usernames and Passwords are **case sensitive**!
 
 ### Credentials Snapshot {#snap-shot}
 
 | Credential Name | Description                                                                                                                                                        | Example                                            |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|
-| `username`      | The **username** of your **API Credentials** for the [Bandwidth Dashboard](https://dashboard.bandwidth.com)                                                        | `jdoe`                                             |
-| `password`      | The **password** of your **API Credentials** for the  [Bandwidth Dashboard](https://dashboard.bandwidth.com)                                                       | `correct-horse-battery-staple`                     |
-| `accountId`     | Your unique account **id**.  The `accountId` is used as part of the url to make API requests. <br> Ex: `https://dashboard.bandwidth.com/api/accounts/{accountId}/` | `920012`                                           |
+| `username`      | Your API user's **username**                                                                                                                                       | `jdoe`                                             |
+| `password`      | Your API user's **password**                                                                                                                                       | `correct-horse-battery-staple`                     |
+| `accountId`     | Your unique **account id**.  The `accountId` is used as part of the url to make API requests. <br> Ex: `https://dashboard.bandwidth.com/api/accounts/{accountId}/` | `920012`                                           |
 
 ## Creating an API User
 

--- a/messaging/errors/httpErrors.md
+++ b/messaging/errors/httpErrors.md
@@ -33,7 +33,7 @@ Bandwidth will return a `HTTP-400` Error when the request is malformed or invali
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
   "from"          : "",
@@ -79,7 +79,7 @@ Bandwidth returns a `HTTP-401` Error when the specified user does not have acces
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
   "from"          : "+19192676804",
@@ -124,7 +124,7 @@ Bandwidth returns a `HTTP-403` error when the user does not have access to the m
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
   "from"          : "+19192676804",
@@ -172,7 +172,7 @@ Bandwidth returns a `HTTP-404` when the path is not found. Ensure the path of th
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages/happy HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
   "from"          : "+19192676804",
@@ -218,7 +218,7 @@ Bandwidth returns a `HTTP-415` error when the content-type of the request is inc
 
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages HTTP/1.1
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 Content-Type: text/plain;charset=UTF-8
 
 {
@@ -265,7 +265,7 @@ For more information about rate limits and queue management, see the [rate limit
 
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{{accountId}}/messages HTTP/1.1
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 Content-Type: text/plain;charset=UTF-8
 
 {

--- a/messaging/methods/media/about.md
+++ b/messaging/methods/media/about.md
@@ -15,7 +15,7 @@ You can upload files up to <code>3.75MB</code> and file storage is free for an u
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API Token and API Secret. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Capabilities
 

--- a/messaging/methods/media/about.md
+++ b/messaging/methods/media/about.md
@@ -15,7 +15,7 @@ You can upload files up to <code>3.75MB</code> and file storage is free for an u
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Capabilities
 

--- a/messaging/methods/media/about.md
+++ b/messaging/methods/media/about.md
@@ -1,6 +1,6 @@
 
 # Media
-The Media resource lets you upload your media files to Bandwidth API servers so they can be used in applications without requiring a separate hosting provider. You can upload files up to `3.75MB` and file storage is free for an unlimited number of files. Files are stored for up to 48 hours. Files you upload can only be accessed by you when you supply your API access `token` and `secret`. They are not available to anonymous users. Bandwidth API supports the `Cache-Control` header when you upload files.
+The Media resource lets you upload your media files to Bandwidth API servers so they can be used in applications without requiring a separate hosting provider. You can upload files up to `3.75MB` and file storage is free for an unlimited number of files. Files are stored for up to 48 hours. Files you upload can only be accessed by you when you supply your API user's username and password. They are not available to anonymous users. Bandwidth API supports the `Cache-Control` header when you upload files.
 
 {% raw %}
 <aside class="alert general small">

--- a/messaging/methods/media/deleteMedia.md
+++ b/messaging/methods/media/deleteMedia.md
@@ -9,7 +9,7 @@ Deletes a media file from Bandwidth API server. Make sure you don't have any app
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 {% common %}
 

--- a/messaging/methods/media/deleteMedia.md
+++ b/messaging/methods/media/deleteMedia.md
@@ -9,7 +9,7 @@ Deletes a media file from Bandwidth API server. Make sure you don't have any app
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API Token and API Secret. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 {% common %}
 
@@ -20,7 +20,7 @@ Bandwidth's messaging API leverages Basic Authentication with your API Token and
 ```bash
 curl -X DELETE \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/media/{mediaName}' \
-	-u '{token}:{secret}'
+	-u '{username}:{password}'
 ```
 
 {% sample lang="csharp" %}

--- a/messaging/methods/media/getMedia.md
+++ b/messaging/methods/media/getMedia.md
@@ -9,11 +9,11 @@ Downloads a media file you previously uploaded.
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API Token and API Secret. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's media API leverages Basic Authentication with your API username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ## ⚠️ Caution on fetching Media ⚠️
 
-You **MUST** use your API token and secret to download the media each and every time you want to access the file.  We **DO NOT** recommend using Bandwidth's url to display/stream media files to your end-users.  Providing your user-id, token, and secret to users' devices is a security risk, as they _could_ use your credentials to access your account.
+You **MUST** use your API username and password to download the media each and every time you want to access the file.  We **DO NOT** recommend using Bandwidth's url to display/stream media files to your end-users.  Providing your account id, username, and password to users' devices is a security risk, as they _could_ use your credentials to access your account.
 
 Instead, we recommend that you create a copy on your local server or a cloud storage service.  Doing so allows you to specify **YOUR** authentication method (if any) to keep your Bandwidth account and users safe.
 
@@ -26,7 +26,7 @@ Instead, we recommend that you create a copy on your local server or a cloud sto
 ```bash
 curl -X GET \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/media/{mediaName}' \
-    -u '{token}:{secret}'
+    -u '{username}:{password}'
 ```
 
 {% sample lang="java" %}

--- a/messaging/methods/media/getMedia.md
+++ b/messaging/methods/media/getMedia.md
@@ -9,7 +9,7 @@ Downloads a media file you previously uploaded.
 
 #### Basic Authentication
 
-Bandwidth's media API leverages Basic Authentication with your API username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's media API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ## ⚠️ Caution on fetching Media ⚠️
 

--- a/messaging/methods/media/listMedia.md
+++ b/messaging/methods/media/listMedia.md
@@ -11,7 +11,7 @@ Each request returns a maximum of 1000 media files. Retrieving more than 1000 me
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ---
 

--- a/messaging/methods/media/listMedia.md
+++ b/messaging/methods/media/listMedia.md
@@ -11,7 +11,7 @@ Each request returns a maximum of 1000 media files. Retrieving more than 1000 me
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API Token and API Secret. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ---
 
@@ -24,7 +24,7 @@ Bandwidth's messaging API leverages Basic Authentication with your API Token and
 | Property      | Description                                   |
 |:--------------|:----------------------------------------------|
 | mediaName     | The mediaName is the unique name of the media |
-| contentLength | Size of the media in Bytes `B`                |
+| contentLength | Size of the media in Bytes                    |
 | content       | URL to use to GET the specific media file.    |
 | Continuation-Token (Response Header) | Token used to retrieve subsequent media. |
 
@@ -38,7 +38,7 @@ Bandwidth's messaging API leverages Basic Authentication with your API Token and
 ```bash
 curl -X GET \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/media' \
-    -u '{token}:{secret}'
+    -u '{username}:{password}'
 ```
 
 > The above command returns JSON structured like this:
@@ -126,7 +126,7 @@ print_r($response->getResult()[0]->mediaName);
 ```bash
 curl -X GET \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/media' \
-    -u '{token}:{secret}' \
+    -u '{username}:{password}' \
     -H "Continuation-Token: 12345"
 ```
 

--- a/messaging/methods/media/uploadMedia.md
+++ b/messaging/methods/media/uploadMedia.md
@@ -10,7 +10,7 @@ Bandwidth retains uploaded media for up to 48 hours.
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API Token and API Secret. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ---
 
@@ -37,7 +37,7 @@ You can upload files up to <code>3.75MB</code> and file storage is free for an u
 curl -X PUT \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/media/{file.mp3}' \
     -H "Content-Type: audio/mpeg" \
-    -u '{token}:{secret}' \
+    -u '{username}:{password}' \
     --data-raw "@{/filepath/file.mp3}"
 ```
 

--- a/messaging/methods/media/uploadMedia.md
+++ b/messaging/methods/media/uploadMedia.md
@@ -10,7 +10,7 @@ Bandwidth retains uploaded media for up to 48 hours.
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ---
 

--- a/messaging/methods/messages/createMessage.md
+++ b/messaging/methods/messages/createMessage.md
@@ -10,7 +10,7 @@ Endpoint for sending text messages and picture messages using V2 messaging.
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Invalid Phone Number Handling
 
@@ -60,7 +60,7 @@ When sending a group message to an invalid phone number, you may receive extrane
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{accountId}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
     "to"            : ["+12345678902"],
@@ -245,7 +245,7 @@ try {
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{accountId}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
     "to"            : ["+12345678902"],
@@ -454,7 +454,7 @@ try {
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{accountId}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
     "to"            : ["+12345678902"],
@@ -665,7 +665,7 @@ try {
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{accountId}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
     "to"            : [
@@ -864,7 +864,7 @@ try {
 ```http
 POST https://messaging.bandwidth.com/api/v2/users/{accountId}/messages HTTP/1.1
 Content-Type: application/json; charset=utf-8
-Authorization: Basic YXBpVG9rZW46YXBpU2VjcmV0
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
 {
     "to"            : [

--- a/messaging/methods/messages/createMessage.md
+++ b/messaging/methods/messages/createMessage.md
@@ -10,7 +10,7 @@ Endpoint for sending text messages and picture messages using V2 messaging.
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Invalid Phone Number Handling
 
@@ -97,7 +97,7 @@ Content-Type: application/json; charset=utf-8
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {
@@ -290,7 +290,7 @@ Content-Type: application/json; charset=utf-8
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {
@@ -500,7 +500,7 @@ Content-Type: application/json; charset=utf-8
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {
@@ -708,7 +708,7 @@ Content-Type: application/json; charset=utf-8
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {
@@ -913,7 +913,7 @@ Content-Type: application/json; charset=utf-8
 ```bash
 curl -X POST \
     --url 'https://messaging.bandwidth.com/api/v2/users/{accountId}/messages' \
-    -u '{apiToken}:{apiSecret}' \
+    -u '{username}:{password}' \
     -H 'Content-type: application/json' \
     --data-raw '
     {

--- a/messaging/methods/messages/getMessages.md
+++ b/messaging/methods/messages/getMessages.md
@@ -14,7 +14,7 @@ Most of the query parameters for this endpoint require URL encoding (exception b
 
 #### Basic Authentication
 
-Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
+Bandwidth's Messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Query Parameters
 

--- a/messaging/methods/messages/getMessages.md
+++ b/messaging/methods/messages/getMessages.md
@@ -14,7 +14,7 @@ Most of the query parameters for this endpoint require URL encoding (exception b
 
 #### Basic Authentication
 
-Authentication on this endpoint is <b>NOT</b> done via API token and secret. Instead, your Dashboard API credentials should be used for basic auth.
+Bandwidth's messaging API leverages Basic Authentication with your API user's username and password. Read more about how Bandwidth secures endpoints in the [Security & Credentials](../../../guides/accountCredentials.md) document.
 
 ### Query Parameters
 
@@ -26,7 +26,7 @@ Authentication on this endpoint is <b>NOT</b> done via API token and secret. Ins
 | messageStatus | string | The status of the message. One of `RECEIVED`, `QUEUED`, `SENDING`, `SENT`, `FAILED`, `DELIVERED`, `ACCEPTED`, `UNDELIVERED` | `RECEIVED` |
 | errorCode | integer | The error code of the message | `9902` |
 | fromDateTime | string | The start of the date range to search in ISO 8601 format. Uses the message receive time. The date range to search in is currently 14 days. | `2016-09-14T18:20:16.000Z` |
-| toDateTime | string | The end of the date range to search in ISO 8601 format. Uses the message receive time. The date range to search in is currently 14 days. | `2016-09-14T18:20:16.000Z^` |
+| toDateTime | string | The end of the date range to search in ISO 8601 format. Uses the message receive time. The date range to search in is currently 14 days. | `2016-09-14T18:20:16.000Z` |
 | pageToken | string | A base64 encoded value used for pagination of results | gdEewhcJLQRB5 |
 | limit | integer | The maximum records requested in search result . Default `100`. <br> The sum of limit and after cannot be more than 10000 | `limit=100` |
 


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes

Our [Account Credentials](https://dev.bandwidth.com/guides/accountCredentials.html) page was updated at some point to instruct customers to create a separate user for accessing the APIs (i.e. separate users for logging in to the dashboard and sending API requests). These API users do Basic auth with username/password, meaning the old Messaging V2 API token/secret framework is no longer needed. Plus customers don't need to worry about using V2 API tokens to access some endpoints and username/password to access others - everything can just be done via the API user.

The docs were updated in some locations to change references from API tokens/secret to username/password. This PR updates the rest (that I could find) to reduce customer (and bandwidth employee!) confusion.

Note that this does NOT update the SDKs, just the docs.