### PR TITLE
MV-4833 explicitly stated the media upload overwrite for same file names

### DIFF
--- a/messaging/methods/media/uploadMedia.md
+++ b/messaging/methods/media/uploadMedia.md
@@ -5,6 +5,8 @@ Uploads a file the normal HTTP way. You may add headers to the request in order 
 
 Bandwidth retains uploaded media for up to 48 hours.
 
+If a file being uploaded has the same name as a file that already exists under that api account, the new file will overwrite the old file.
+
 ### Request URL
 <code class="put">PUT</code>`https://messaging.bandwidth.com/api/v2/users/{accountId}/media/{mediaName}`
 


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes

