### PR TITLE
EDGE-591 Add deviceApiVersion parameter to WebRTC Participant endpoints

### DIFF
--- a/webrtc/methods/participants/createParticipant.md
+++ b/webrtc/methods/participants/createParticipant.md
@@ -25,8 +25,9 @@ You should not include sensitive or personally-identifiable information in any t
 | Parameter                   | Description                                                                                       
 |:----------------------------|:--------------------------------------------------------------------------------------------------
 | callbackUrl                 | Full callback url to use for notifications about this participant                                 
-| publishPermissions          | Defines the types of media this participant can publish. Accepted values: `AUDIO`,`VIDEO`                                                                                           
-| tag                         | User defined tag to associate with the participant                                                
+| publishPermissions          | Defines the types of media this participant can publish. Accepted values: `AUDIO`,`VIDEO`
+| tag                         | User defined tag to associate with the participant
+| deviceApiVersion            | Optional parameter that sets the version of the signaling API the participant will use. Accepted values: `V2`,`V3`. Defaults to `V2`
 
 
 ### Response Attributes
@@ -83,7 +84,8 @@ curl -X POST
               } 
          ]
      },
-      "tag"                 : "participant1"
+      "tag"                 : "participant1",
+      "deviceApiVersion": "V2"
  },
   "token"               : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyfQ.L8i6g3PfcHlioHCCPURC9pmXT7gdJpx3kOoyAfNUwCc"
 }

--- a/webrtc/methods/participants/getParticipant.md
+++ b/webrtc/methods/participants/getParticipant.md
@@ -21,7 +21,8 @@ Bandwidth WebRTC API leverages Basic Authentication with your Dashboard API Cred
 | publishPermissions          | Defines if this participant can publish audio or video                                            
 | sessions                    | List of session ids this participant is associated with                                           
 | subscriptions               | Subscription information for this participant, which lists the sessions and IDs of Participants publishing media
-| tag                         | User defined tag to associate with the participant                                                
+| tag                         | User defined tag to associate with the participant
+| deviceApiVersion            | The version of the signaling API the participant will use 
 
 
 
@@ -61,7 +62,8 @@ curl -X GET
           } 
      ]
  },
-  "tag"                 : "participant1"
+  "tag"                 : "participant1",
+  "deviceApiVersion"    : "V2"
 }
 ```
 


### PR DESCRIPTION
## Brief Summary of changes
Adds info about the the new, optional, `deviceApiVersion` parameter to WebRTC Participant endpoints

