### PR TITLE
TDP-5379: Allow multiple UUI

### DIFF
--- a/voice/bxml/verbs/transfer.md
+++ b/voice/bxml/verbs/transfer.md
@@ -56,7 +56,7 @@ one destination is specified, called parties will ring simultaneously and the fi
 #### SipUri attributes
 | Attribute | Description |
 |:----------|:------------|
-| uui | (optional) The value of the `User-To-User` header to send within the initial `INVITE`. Must include the `encoding` parameter as specified in [`RFC 7433`](https://tools.ietf.org/html/rfc7433). Only `base64` and `jwt` encoding are currently allowed. This value, including the encoding specifier, may not exceed 256 characters. |
+| uui | (optional) A comma-separated list of `User-To-User` headers to send within the initial `INVITE`. Each value must end with the `encoding` parameter as specified in [`RFC 7433`](https://tools.ietf.org/html/rfc7433). Only `base64` and `jwt` encodings are currently allowed. The entire value cannot exceed 350 characters, including parameters and separators. Example: `<jwt-value>;encoding=jwt,<base64-value>;encoding=base64` |
 | transferAnswerUrl | (optional) URL, if any, to send the [Transfer Answer](../callbacks/transferAnswer.md) event to and request BXML to be executed for the called party before the call is bridged. May be a relative URL. |
 | transferAnswerMethod | (optional) The HTTP method to use for the request to `transferAnswerUrl`. GET or POST. Default value is POST. |
 | transferAnswerFallbackUrl | (optional) A fallback url which, if provided, will be used to retry the [Transfer Answer](../callbacks/transferAnswer.md) callback delivery in case `transferAnswerUrl` fails to respond. |

--- a/voice/methods/calls/postCalls.md
+++ b/voice/methods/calls/postCalls.md
@@ -40,7 +40,7 @@ You should not include sensitive or personally-identifiable information in any t
 | fallbackUsername | (optional) The username to send in the HTTP request to `answerFallbackUrl` | No |
 | fallbackPassword | (optional) The password to send in the HTTP request to `answerFallbackUrl` | No |
 | callbackTimeout | (optional) This is the timeout (in seconds) to use when delivering callbacks for the call. Can be any numeric value (including decimals) between 1 and 25. Default: 15 | No |
-| uui | (optional) The value of the `User-To-User` header to send within the initial `INVITE` when calling a SIP URI. Must include the `encoding` parameter as specified in [`RFC 7433`](https://tools.ietf.org/html/rfc7433). Only `base64` and `jwt` encoding are currently allowed. This value, including the encoding specifier, may not exceed 256 characters. | No |
+| uui | (optional) A comma-separated list of `User-To-User` headers to send within the initial `INVITE`. Each value must end with the `encoding` parameter as specified in [`RFC 7433`](https://tools.ietf.org/html/rfc7433). Only `base64` and `jwt` encodings are currently allowed. The entire value cannot exceed 350 characters, including parameters and separators. Example: `<jwt-value>;encoding=jwt,<base64-value>;encoding=base64` | No |
 
 **NOTE:** Any error that causes the call to be hung up (for example invalid BXML or rate limiting) will be delivered to the `disconnectUrl` via a [Disconnect](../../bxml/callbacks/disconnect.md) event.  This is currently the only way to receive user errors, so while `disconnectUrl` is not mandatory, we highly recommend providing it so that user errors can be delivered.
 


### PR DESCRIPTION
### Changes

- Increase `uui` attribute size from 256 to 350 (in both BXML and API)
- Allow comma-separated multiple UUI values as such: `value1;encoding=enc1,value2;encoding=enc2,...`
  - All values required to end with encoding
  - The size limit is applied to the whole string (includes encoding and commas)