### PR TITLE
VAPI-746: Ring verb can now ring without answering the call

### DIFF
--- a/voice/bxml/verbs/ring.md
+++ b/voice/bxml/verbs/ring.md
@@ -8,7 +8,7 @@ The Ring verb is used to play ringing audio on a call.
 | ATTRIBUTE | Description                                                                                            |
 |:----------|:-------------------------------------------------------------------------------------------------------|
 | duration  | (optional) How many seconds to play ringing on the call. Default value is 5. Range: decimal values between 0.1 - 86400.
-| answerCall  | (optional) A boolean indicating whether or not to pick up the call when Ring is the first verb on an unanswered incoming call. Default value is true.
+| answerCall  | (optional) A boolean indicating whether or not to answer the call when Ring is executed on an unanswered incoming call. Default value is 'true'.
 
 ### Callbacks Received
 

--- a/voice/bxml/verbs/ring.md
+++ b/voice/bxml/verbs/ring.md
@@ -8,6 +8,7 @@ The Ring verb is used to play ringing audio on a call.
 | ATTRIBUTE | Description                                                                                            |
 |:----------|:-------------------------------------------------------------------------------------------------------|
 | duration  | (optional) How many seconds to play ringing on the call. Default value is 5. Range: decimal values between 0.1 - 86400.
+| answerCall  | (optional) A boolean indicating whether or not to pick up the call when Ring is the first verb on an unanswered incoming call. Default value is true.
 
 ### Callbacks Received
 


### PR DESCRIPTION
## For the Committer

⚠️ Ensure that for this repo (**bandwidth.github.io**) that the pull request change is opened against the branch `stop-gap-v2`

## Brief Summary of changes

